### PR TITLE
:sparkles: group hooks and description

### DIFF
--- a/crescent/commands/decorators.py
+++ b/crescent/commands/decorators.py
@@ -126,8 +126,6 @@ def command(
     *,
     guild: Optional[Snowflakeish] = None,
     name: Optional[str] = None,
-    group: Optional[str] = None,
-    sub_group: Optional[str] = None,
     description: Optional[str] = None,
 ) -> Callable[
     [CommandCallback | Type[ClassCommandProto]],
@@ -142,8 +140,6 @@ def command(
     *,
     guild: Optional[Snowflakeish] = None,
     name: Optional[str] = None,
-    group: Optional[str] = None,
-    sub_group: Optional[str] = None,
     description: Optional[str] = None,
 ):
     if not callback:
@@ -151,8 +147,6 @@ def command(
             command,
             guild=guild,
             name=name,
-            group=group,
-            sub_group=sub_group,
             description=description,
         )
 
@@ -200,8 +194,6 @@ def command(
         callback=callback_func,
         guild=guild,
         name=name,
-        group=group,
-        sub_group=sub_group,
         description=description,
         options=options,
     )

--- a/crescent/commands/groups.py
+++ b/crescent/commands/groups.py
@@ -1,6 +1,4 @@
 from __future__ import annotations
-
-from cgitb import Hook
 from typing import TYPE_CHECKING
 
 from attr import define

--- a/crescent/commands/groups.py
+++ b/crescent/commands/groups.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from cgitb import Hook
 
 from typing import TYPE_CHECKING
 
@@ -23,8 +24,18 @@ class Group:
     description: Optional[str] = None
     hooks: Optional[List[HookCallbackT]] = None
 
-    def sub_group(self, name: str, description: Optional[str] = None) -> SubGroup:
-        return SubGroup(name=name, parent=self, description=description)
+    def sub_group(
+        self,
+        name: str,
+        description: Optional[str] = None,
+        hooks: Optional[List[HookCallbackT]] = None,
+    ) -> SubGroup:
+        return SubGroup(
+            name=name,
+            parent=self,
+            description=description,
+            hooks=hooks,
+        )
 
     def child(
         self, meta: MetaStruct[CommandCallback, AppCommandMeta]

--- a/crescent/commands/groups.py
+++ b/crescent/commands/groups.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from cgitb import Hook
 
 from typing import TYPE_CHECKING
 

--- a/crescent/commands/groups.py
+++ b/crescent/commands/groups.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from attr import define

--- a/crescent/commands/groups.py
+++ b/crescent/commands/groups.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from attr import define
 
 if TYPE_CHECKING:
-    from typing import Sequence
+    from typing import Optional, Sequence
 
     from crescent.internal.app_command import AppCommandMeta
     from crescent.internal.meta_struct import MetaStruct
@@ -20,25 +20,27 @@ __all__: Sequence[str] = (
 @define
 class Group:
     name: str
+    description: Optional[str] = None
 
-    def sub_group(self, name: str) -> SubGroup:
-        return SubGroup(name, self.name)
+    def sub_group(self, name: str, description: Optional[str] = None) -> SubGroup:
+        return SubGroup(name=name, parent=self, description=description)
 
     def child(
         self, meta: MetaStruct[CommandCallback, AppCommandMeta]
     ) -> MetaStruct[CommandCallback, AppCommandMeta]:
-        meta.metadata.group = self.name
+        meta.metadata.group = self
         return meta
 
 
 @define
 class SubGroup:
     name: str
-    parent: str
+    parent: Group
+    description: Optional[str] = None
 
     def child(
         self, meta: MetaStruct[CommandCallback, AppCommandMeta]
     ) -> MetaStruct[CommandCallback, AppCommandMeta]:
         meta.metadata.group = self.parent
-        meta.metadata.sub_group = self.name
+        meta.metadata.sub_group = self
         return meta

--- a/crescent/commands/groups.py
+++ b/crescent/commands/groups.py
@@ -32,7 +32,7 @@ class Group:
         meta.metadata.group = self
 
         if self.hooks:
-            meta.interaction_hooks.insert(0, self.hooks)
+            meta.interaction_hooks = self.hooks + meta.interaction_hooks
 
         return meta
 
@@ -51,9 +51,9 @@ class SubGroup:
         meta.metadata.sub_group = self
 
         if self.hooks:
-            meta.interaction_hooks.insert(0, self.hooks)
+            meta.interaction_hooks = self.hooks + meta.interaction_hooks
 
         if self.parent.hooks:
-            meta.interaction_hooks.insert(0, self.parent.hooks)
+            meta.interaction_hooks = self.parent.hooks + meta.interaction_hooks
 
         return meta

--- a/crescent/internal/app_command.py
+++ b/crescent/internal/app_command.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
     from hikari import Snowflake, UndefinedNoneOr, UndefinedOr
 
+    from crescent.commands.groups import Group, SubGroup
     from crescent.typedefs import CommandCallback
 
 
@@ -40,8 +41,8 @@ class Unique:
             name=command.metadata.app.name,
             type=command.metadata.app.type,
             guild_id=command.metadata.app.guild_id,
-            group=command.metadata.group,
-            sub_group=command.metadata.sub_group,
+            group=command.metadata.group.name if command.metadata.group else None,
+            sub_group=command.metadata.sub_group.name if command.metadata.sub_group else None,
         )
 
     @classmethod
@@ -50,8 +51,8 @@ class Unique:
             name=command.app.name,
             type=command.app.type,
             guild_id=command.app.guild_id,
-            group=command.group,
-            sub_group=command.sub_group,
+            group=command.group.name if command.group else None,
+            sub_group=command.sub_group.name if command.sub_group else None,
         )
 
 
@@ -104,8 +105,8 @@ class AppCommand:
 @define
 class AppCommandMeta:
     app: AppCommand
-    group: Optional[str] = None
-    sub_group: Optional[str] = None
+    group: Optional[Group] = None
+    sub_group: Optional[SubGroup] = None
 
     @property
     def unique(self) -> Unique:
@@ -113,6 +114,6 @@ class AppCommandMeta:
             self.app.name,
             self.app.type,
             self.app.guild_id,
-            self.group,
-            self.sub_group,
+            self.group.name if self.group else None,
+            self.sub_group.name if self.sub_group else None,
         )

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -41,8 +41,6 @@ _log = getLogger(__name__)
 def register_command(
     callback: Callable[..., Awaitable[Any]],
     guild: Optional[Snowflakeish] = None,
-    group: Optional[str] = None,
-    sub_group: Optional[str] = None,
     name: Optional[str] = None,
     description: Optional[str] = None,
     options: Optional[Sequence[CommandOption]] = None,
@@ -62,8 +60,6 @@ def register_command(
         callback=callback,
         app_set_hooks=[hook],
         metadata=AppCommandMeta(
-            group=group,
-            sub_group=sub_group,
             app=AppCommand(
                 type=AppCommandType.CHAT_INPUT,
                 description=description,
@@ -167,7 +163,7 @@ class CommandHandler:
                 # `key` represents the unique value for the top-level command that will
                 # hold the subcommand.
                 key = Unique(
-                    name=unwrap(command.metadata.group),
+                    name=unwrap(command.metadata.group).name,
                     type=command.metadata.app.type,
                     guild_id=command.metadata.app.guild_id,
                     group=None,
@@ -176,8 +172,8 @@ class CommandHandler:
 
                 if key not in built_commands:
                     built_commands[key] = AppCommand(
-                        name=unwrap(command.metadata.group),
-                        description="HIDDEN",
+                        name=unwrap(command.metadata.group).name,
+                        description=unwrap(command.metadata.group).description or "\u200B",
                         type=AppCommandType.CHAT_INPUT,
                         guild_id=command.metadata.app.guild_id,
                         options=[],
@@ -190,8 +186,8 @@ class CommandHandler:
                 children = unwrap(built_commands[key].options)
 
                 sub_command_group = CommandOption(
-                    name=command.metadata.sub_group,
-                    description="HIDDEN",
+                    name=unwrap(command.metadata.sub_group).name,
+                    description=unwrap(command.metadata.sub_group).description or "\u200B",
                     type=OptionType.SUB_COMMAND_GROUP,
                     options=[],
                     is_required=None,  # type: ignore
@@ -236,7 +232,7 @@ class CommandHandler:
                 # `key` represents the unique value for the top-level command that will
                 # hold the subcommand.
                 key = Unique(
-                    name=command.metadata.group,
+                    name=command.metadata.group.name,
                     type=command.metadata.app.type,
                     guild_id=command.metadata.app.guild_id,
                     group=None,
@@ -245,7 +241,7 @@ class CommandHandler:
 
                 if key not in built_commands:
                     built_commands[key] = AppCommand(
-                        name=command.metadata.group,
+                        name=command.metadata.group.name,
                         description="HIDDEN",
                         type=command.metadata.app.type,
                         guild_id=command.metadata.app.guild_id,


### PR DESCRIPTION
- rework groups to use object
- add hooks

Groups are now stored as the object instead of a `str`. I also removed the `group` and `sub_group` params in the `@crescent.command` decorator so now you can only use `@group.child` and `@sub_group.child`