### PR TITLE
✨ Ctx `options`, `command`, `group`, `sub_group`, `command_type`

### DIFF
--- a/crescent/commands/errors.py
+++ b/crescent/commands/errors.py
@@ -15,7 +15,6 @@ from crescent.internal.meta_struct import MetaStruct
 
 if TYPE_CHECKING:
     from crescent.context import Context
-    from crescent.typedefs import CommandOptionsT
 
 
 ERROR = TypeVar("ERROR", bound=Exception, contravariant=True)
@@ -28,7 +27,6 @@ class ErrorHandlerProto(Protocol, Generic[ERROR]):
         *,
         exc: ERROR,
         ctx: Context,
-        options: CommandOptionsT,
     ) -> None:
         ...
 

--- a/crescent/commands/errors.py
+++ b/crescent/commands/errors.py
@@ -12,13 +12,7 @@ ERROR = TypeVar("ERROR", bound=Exception, contravariant=True)
 
 
 class ErrorHandlerProto(Protocol, Generic[ERROR]):
-    async def __call__(
-        self,
-        /,
-        *,
-        exc: ERROR,
-        ctx: Context,
-    ) -> None:
+    async def __call__(self, /, *, exc: ERROR, ctx: Context) -> None:
         ...
 
 

--- a/crescent/commands/hooks.py
+++ b/crescent/commands/hooks.py
@@ -36,14 +36,10 @@ def hook(callback: HookCallbackT, command: T, /) -> T:
     ...
 
 
-def hook(callback, command=None):
-
+def hook(callback: HookCallbackT, command: T | None = None) -> T | Callable[..., T]:
     if command is None:
-        return partial(hook, callback)
-
+        return partial(hook, callback)  # type: ignore
     if not iscoroutinefunction(callback):
         raise ValueError(f"Function `{callback.__name__}` must be async.")
-
-    command.interaction_hooks.insert(0, callback)
-
+    command.metadata.hooks.insert(0, callback)
     return command

--- a/crescent/commands/hooks.py
+++ b/crescent/commands/hooks.py
@@ -36,7 +36,7 @@ def hook(callback: HookCallbackT, command: T, /) -> T:
     ...
 
 
-def hook(callback: HookCallbackT, command: T | None = None) -> T | partial:
+def hook(callback, command=None):
 
     if command is None:
         return partial(hook, callback)
@@ -44,6 +44,6 @@ def hook(callback: HookCallbackT, command: T | None = None) -> T | partial:
     if not iscoroutinefunction(callback):
         raise ValueError(f"Function `{callback.__name__}` must be async.")
 
-    command.metadata.hooks.insert(0, callback)
+    command.interaction_hooks.insert(0, callback)
 
     return command

--- a/crescent/commands/hooks.py
+++ b/crescent/commands/hooks.py
@@ -7,11 +7,11 @@ from typing import TYPE_CHECKING, Sequence, overload
 from attrs import define
 
 if TYPE_CHECKING:
-    from typing import Any, Awaitable, Callable, Optional, TypeVar
+    from typing import Any, Awaitable, Callable, TypeVar
 
     from crescent.internal.app_command import AppCommandMeta
     from crescent.internal.meta_struct import MetaStruct
-    from crescent.typedefs import CommandOptionsT, HookCallbackT
+    from crescent.typedefs import HookCallbackT
 
     T = TypeVar("T", bound="MetaStruct[Callable[..., Awaitable[Any]], AppCommandMeta]")
 
@@ -24,7 +24,6 @@ __all__: Sequence[str] = (
 @define
 class HookResult:
     exit: bool = False
-    options: Optional[CommandOptionsT] = None
 
 
 @overload

--- a/crescent/commands/hooks.py
+++ b/crescent/commands/hooks.py
@@ -36,7 +36,7 @@ def hook(callback: HookCallbackT, command: T, /) -> T:
     ...
 
 
-def hook(callback, command=None):
+def hook(callback: HookCallbackT, command: T | None = None) -> T | partial:
 
     if command is None:
         return partial(hook, callback)
@@ -44,6 +44,6 @@ def hook(callback, command=None):
     if not iscoroutinefunction(callback):
         raise ValueError(f"Function `{callback.__name__}` must be async.")
 
-    command.interaction_hooks.insert(0, callback)
+    command.metadata.hooks.insert(0, callback)
 
     return command

--- a/crescent/context.py
+++ b/crescent/context.py
@@ -7,27 +7,22 @@ from attr import define
 from hikari import (
     UNDEFINED,
     CacheAware,
-    CommandInteractionOption,
-    CommandType,
     Guild,
     GuildChannel,
     Member,
     MessageFlag,
-    OptionType,
     ResponseType,
     RESTAware,
     Snowflake,
     User,
 )
 
-from crescent.mentionable import Mentionable
-from crescent.utils import map_or, unwrap
+from crescent.utils import map_or
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Mapping, Optional, Sequence, Type
+    from typing import Any, Dict, Optional, Sequence
 
     from hikari import (
-        CommandInteraction,
         Embed,
         Message,
         PartialRole,
@@ -40,59 +35,12 @@ if TYPE_CHECKING:
     )
     from hikari.api import ComponentBuilder
 
-    from crescent.typedefs import OptionTypesT
-
 
 class RestAndCacheAware(RESTAware, CacheAware):
     ...
 
 
 __all__: Sequence[str] = ("Context",)
-
-
-_VALUE_TYPE_LINK: Dict[OptionType | int, str] = {
-    OptionType.ROLE: "roles",
-    OptionType.USER: "users",
-    OptionType.CHANNEL: "channels",
-}
-
-
-def _options_to_kwargs(
-    interaction: CommandInteraction, options: Optional[Sequence[CommandInteractionOption]]
-) -> Dict[str, Any]:
-    if not options:
-        return {}
-
-    return {option.name: _extract_value(option, interaction) for option in options}
-
-
-def _extract_value(option: CommandInteractionOption, interaction: CommandInteraction) -> Any:
-    if option.type is OptionType.MENTIONABLE:
-        return Mentionable._from_interaction(interaction)
-
-    resolved_type: Optional[str] = _VALUE_TYPE_LINK.get(option.type)
-
-    if resolved_type is None:
-        return option.value
-
-    resolved = getattr(interaction.resolved, resolved_type)
-    return resolved[option.value]
-
-
-def _resolved_data_to_kwargs(interaction: CommandInteraction) -> Dict[str, Message | User]:
-    if not interaction.resolved:
-        raise ValueError("interaction.resoved should be defined when running this function")
-
-    if interaction.resolved.messages:
-        return {"message": next(iter(interaction.resolved.messages.values()))}
-    if interaction.resolved.members:
-        return {"user": next(iter(interaction.resolved.members.values()))}
-    if interaction.resolved.users:
-        return {"user": next(iter(interaction.resolved.users.values()))}
-
-    raise AttributeError(
-        "interaction.resolved did not have property `messages`, `members`, or `users`"
-    )
 
 
 @define
@@ -119,48 +67,6 @@ class Context:
 
     _has_replied: bool = False
     _used_first_resp: bool = False
-
-    @classmethod
-    def _from_command_interaction(cls: Type[Context], interaction: CommandInteraction) -> Context:
-        name: str = interaction.command_name
-        group: Optional[str] = None
-        sub_group: Optional[str] = None
-        options = interaction.options
-
-        if options:
-            option = options[0]
-            if option.type == 1:
-                group = name
-                name = option.name
-                options = option.options
-            elif option.type == 2:
-                group = interaction.command_name
-                sub_group = option.name
-                name = unwrap(option.options)[0].name
-
-        callback_options: Mapping[str, OptionTypesT | Message | User]
-        if interaction.command_type is CommandType.SLASH:
-            callback_options = _options_to_kwargs(interaction, options)
-        else:
-            callback_options = _resolved_data_to_kwargs(interaction)
-
-        return cls(
-            app=cast(RestAndCacheAware, interaction.app),
-            application_id=interaction.application_id,
-            type=interaction.type,
-            token=interaction.token,
-            id=interaction.id,
-            version=interaction.version,
-            channel_id=interaction.channel_id,
-            guild_id=interaction.guild_id,
-            user=interaction.user,
-            member=interaction.member,
-            command=name,
-            group=group,
-            sub_group=sub_group,
-            command_type=hikari.CommandType(interaction.command_type),
-            options=callback_options,
-        )
 
     @property
     def channel(self) -> Optional[GuildChannel]:

--- a/crescent/context.py
+++ b/crescent/context.py
@@ -20,7 +20,7 @@ from hikari import (
 from crescent.utils import map_or
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Optional, Sequence, Literal
+    from typing import Any, Dict, Literal, Optional, Sequence
 
     from hikari import (
         Embed,

--- a/crescent/context.py
+++ b/crescent/context.py
@@ -1,22 +1,27 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Dict, Mapping, cast
 
 from attr import define
 from hikari import (
     UNDEFINED,
     CacheAware,
+    CommandInteractionOption,
+    CommandType,
     Guild,
     GuildChannel,
     Member,
     MessageFlag,
+    OptionType,
     ResponseType,
     RESTAware,
     Snowflake,
     User,
 )
+import hikari
 
-from crescent.utils import map_or
+from crescent.utils import map_or, unwrap
+from crescent.mentionable import Mentionable
 
 if TYPE_CHECKING:
     from typing import Any, Optional, Sequence, Type
@@ -35,12 +40,60 @@ if TYPE_CHECKING:
     )
     from hikari.api import ComponentBuilder
 
+    from crescent.typedefs import OptionTypesT
+
 
 class RestAndCacheAware(RESTAware, CacheAware):
     ...
 
 
 __all__: Sequence[str] = ("Context",)
+
+
+_VALUE_TYPE_LINK: Dict[OptionType | int, str] = {
+    OptionType.ROLE: "roles",
+    OptionType.USER: "users",
+    OptionType.CHANNEL: "channels",
+}
+
+
+def _options_to_kwargs(
+    interaction: CommandInteraction,
+    options: Optional[Sequence[CommandInteractionOption]],
+) -> Dict[str, Any]:
+    if not options:
+        return {}
+
+    return {option.name: _extract_value(option, interaction) for option in options}
+
+
+def _extract_value(option: CommandInteractionOption, interaction: CommandInteraction) -> Any:
+    if option.type is OptionType.MENTIONABLE:
+        return Mentionable._from_interaction(interaction)
+
+    resolved_type: Optional[str] = _VALUE_TYPE_LINK.get(option.type)
+
+    if resolved_type is None:
+        return option.value
+
+    resolved = getattr(interaction.resolved, resolved_type)
+    return resolved[option.value]
+
+
+def _resolved_data_to_kwargs(interaction: CommandInteraction) -> Dict[str, Message | User]:
+    if not interaction.resolved:
+        raise ValueError("interaction.resoved should be defined when running this function")
+
+    if interaction.resolved.messages:
+        return {"message": next(iter(interaction.resolved.messages.values()))}
+    if interaction.resolved.members:
+        return {"user": next(iter(interaction.resolved.members.values()))}
+    if interaction.resolved.users:
+        return {"user": next(iter(interaction.resolved.users.values()))}
+
+    raise AttributeError(
+        "interaction.resolved did not have property `messages`, `members`, or `users`"
+    )
 
 
 @define
@@ -59,11 +112,39 @@ class Context:
     user: User
     member: Optional[Member]
 
+    command: str
+    command_type: hikari.CommandType
+    group: Optional[str]
+    sub_group: Optional[str]
+    options: Dict[str, Any]
+
     _has_replied: bool = False
     _used_first_resp: bool = False
 
     @classmethod
     def _from_command_interaction(cls: Type[Context], interaction: CommandInteraction) -> Context:
+        name: str = interaction.command_name
+        group: Optional[str] = None
+        sub_group: Optional[str] = None
+        options = interaction.options
+
+        if options:
+            option = options[0]
+            if option.type == 1:
+                group = name
+                name = option.name
+                options = option.options
+            elif option.type == 2:
+                group = interaction.command_name
+                sub_group = option.name
+                name = unwrap(option.options)[0].name
+
+        callback_options: Mapping[str, OptionTypesT | Message | User]
+        if interaction.command_type is CommandType.SLASH:
+            callback_options = _options_to_kwargs(interaction, options)
+        else:
+            callback_options = _resolved_data_to_kwargs(interaction)
+
         return cls(
             app=cast(RestAndCacheAware, interaction.app),
             application_id=interaction.application_id,
@@ -75,6 +156,11 @@ class Context:
             guild_id=interaction.guild_id,
             user=interaction.user,
             member=interaction.member,
+            command=name,
+            group=group,
+            sub_group=sub_group,
+            command_type=hikari.CommandType(interaction.command_type),
+            options=callback_options,
         )
 
     @property

--- a/crescent/context.py
+++ b/crescent/context.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast, overload
+from typing import TYPE_CHECKING, overload
 
 import hikari
 from attr import define
@@ -20,7 +20,7 @@ from hikari import (
 from crescent.utils import map_or
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Optional, Sequence
+    from typing import Any, Dict, Optional, Sequence, Literal
 
     from hikari import (
         Embed,

--- a/crescent/context.py
+++ b/crescent/context.py
@@ -58,8 +58,7 @@ _VALUE_TYPE_LINK: Dict[OptionType | int, str] = {
 
 
 def _options_to_kwargs(
-    interaction: CommandInteraction,
-    options: Optional[Sequence[CommandInteractionOption]],
+    interaction: CommandInteraction, options: Optional[Sequence[CommandInteractionOption]]
 ) -> Dict[str, Any]:
     if not options:
         return {}

--- a/crescent/context.py
+++ b/crescent/context.py
@@ -24,7 +24,7 @@ from crescent.mentionable import Mentionable
 from crescent.utils import map_or, unwrap
 
 if TYPE_CHECKING:
-    from typing import Any, Optional, Sequence, Type, Dict, Mapping
+    from typing import Any, Dict, Mapping, Optional, Sequence, Type
 
     from hikari import (
         CommandInteraction,

--- a/crescent/context.py
+++ b/crescent/context.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Dict, Mapping, cast
 
+import hikari
 from attr import define
 from hikari import (
     UNDEFINED,
@@ -18,10 +19,9 @@ from hikari import (
     Snowflake,
     User,
 )
-import hikari
 
-from crescent.utils import map_or, unwrap
 from crescent.mentionable import Mentionable
+from crescent.utils import map_or, unwrap
 
 if TYPE_CHECKING:
     from typing import Any, Optional, Sequence, Type

--- a/crescent/context.py
+++ b/crescent/context.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Mapping, cast
+from typing import TYPE_CHECKING, cast
 
 import hikari
 from attr import define
@@ -24,7 +24,7 @@ from crescent.mentionable import Mentionable
 from crescent.utils import map_or, unwrap
 
 if TYPE_CHECKING:
-    from typing import Any, Optional, Sequence, Type
+    from typing import Any, Optional, Sequence, Type, Dict, Mapping
 
     from hikari import (
         CommandInteraction,

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -1,23 +1,37 @@
 from __future__ import annotations
 
 from contextlib import suppress
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Mapping, Optional, cast
 
-from hikari import UNDEFINED, CommandInteraction, Snowflake
+from hikari import (
+    UNDEFINED,
+    CommandType,
+    OptionType,
+)
 
 from crescent.context import Context
 from crescent.exceptions import CommandNotFoundError
 from crescent.internal.app_command import Unique
-from crescent.utils.gather_iter import gather_iter
+from crescent.utils import gather_iter, unwrap
+from crescent.mentionable import Mentionable
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Sequence, cast
+    from typing import Any, Dict, Sequence
 
-    from hikari import InteractionCreateEvent
+    from hikari import (
+        InteractionCreateEvent,
+        CommandInteraction,
+        CommandInteractionOption,
+        Message,
+        Snowflake,
+        User,
+    )
 
     from crescent.bot import Bot
     from crescent.internal import AppCommandMeta, MetaStruct
     from crescent.typedefs import CommandCallbackT
+    from crescent.context import RestAndCacheAware
+    from crescent.typedefs import OptionTypesT
 
 
 __all__: Sequence = ("handle_resp",)
@@ -32,9 +46,14 @@ async def handle_resp(event: InteractionCreateEvent):
         interaction = cast(CommandInteraction, interaction)
         bot = cast(Bot, bot)
 
-    ctx = Context._from_command_interaction(interaction)
+    ctx = _context_from_interaction_resp(interaction)
     command = _get_command(
-        bot, ctx.command, int(ctx.command_type), ctx.guild_id, ctx.group, ctx.sub_group
+        bot,
+        ctx.command,
+        int(ctx.command_type),
+        ctx.guild_id,
+        ctx.group,
+        ctx.sub_group,
     )
 
     for hook in command.metadata.hooks:
@@ -48,7 +67,9 @@ async def handle_resp(event: InteractionCreateEvent):
             await command.callback(ctx, **ctx.options)
         except Exception as e:
             if hdlrs := command.app._error_handler.registry.get(e.__class__):
-                await gather_iter(func.callback(exc=e, ctx=ctx) for func in hdlrs)
+                await gather_iter(
+                    func.callback(exc=e, ctx=ctx) for func in hdlrs
+                )
             else:
                 raise
 
@@ -62,10 +83,114 @@ def _get_command(
     sub_group: Optional[str],
 ) -> MetaStruct[CommandCallbackT, AppCommandMeta]:
 
-    kwargs: Dict[str, Any] = dict(name=name, type=type, group=group, sub_group=sub_group)
+    kwargs: Dict[str, Any] = dict(
+        name=name, type=type, group=group, sub_group=sub_group
+    )
 
     with suppress(KeyError):
-        return bot._command_handler.registry[Unique(guild_id=guild_id, **kwargs)]
+        return bot._command_handler.registry[
+            Unique(guild_id=guild_id, **kwargs)
+        ]
     with suppress(KeyError):
-        return bot._command_handler.registry[Unique(guild_id=UNDEFINED, **kwargs)]
-    raise CommandNotFoundError(f"Handler for command `{name}` does not exist locally.")
+        return bot._command_handler.registry[
+            Unique(guild_id=UNDEFINED, **kwargs)
+        ]
+    raise CommandNotFoundError(
+        f"Handler for command `{name}` does not exist locally."
+    )
+
+
+_VALUE_TYPE_LINK: Dict[OptionType | int, str] = {
+    OptionType.ROLE: "roles",
+    OptionType.USER: "users",
+    OptionType.CHANNEL: "channels",
+}
+
+
+def _context_from_interaction_resp(interaction: CommandInteraction) -> Context:
+    name: str = interaction.command_name
+    group: Optional[str] = None
+    sub_group: Optional[str] = None
+    options = interaction.options
+
+    if options:
+        option = options[0]
+        if option.type == 1:
+            group = name
+            name = option.name
+            options = option.options
+        elif option.type == 2:
+            group = interaction.command_name
+            sub_group = option.name
+            name = unwrap(option.options)[0].name
+
+    callback_options: Mapping[str, OptionTypesT | Message | User]
+    if interaction.command_type is CommandType.SLASH:
+        callback_options = _options_to_kwargs(interaction, options)
+    else:
+        callback_options = _resolved_data_to_kwargs(interaction)
+
+    return Context(
+        app=cast("RestAndCacheAware", interaction.app),
+        application_id=interaction.application_id,
+        type=interaction.type,
+        token=interaction.token,
+        id=interaction.id,
+        version=interaction.version,
+        channel_id=interaction.channel_id,
+        guild_id=interaction.guild_id,
+        user=interaction.user,
+        member=interaction.member,
+        command=name,
+        group=group,
+        sub_group=sub_group,
+        command_type=CommandType(interaction.command_type),
+        options=callback_options,
+    )
+
+
+def _options_to_kwargs(
+    interaction: CommandInteraction,
+    options: Optional[Sequence[CommandInteractionOption]],
+) -> Dict[str, Any]:
+    if not options:
+        return {}
+
+    return {
+        option.name: _extract_value(option, interaction) for option in options
+    }
+
+
+def _extract_value(
+    option: CommandInteractionOption, interaction: CommandInteraction
+) -> Any:
+    if option.type is OptionType.MENTIONABLE:
+        return Mentionable._from_interaction(interaction)
+
+    resolved_type: Optional[str] = _VALUE_TYPE_LINK.get(option.type)
+
+    if resolved_type is None:
+        return option.value
+
+    resolved = getattr(interaction.resolved, resolved_type)
+    return resolved[option.value]
+
+
+def _resolved_data_to_kwargs(
+    interaction: CommandInteraction,
+) -> Dict[str, Message | User]:
+    if not interaction.resolved:
+        raise ValueError(
+            "interaction.resoved should be defined when running this function"
+        )
+
+    if interaction.resolved.messages:
+        return {"message": next(iter(interaction.resolved.messages.values()))}
+    if interaction.resolved.members:
+        return {"user": next(iter(interaction.resolved.members.values()))}
+    if interaction.resolved.users:
+        return {"user": next(iter(interaction.resolved.users.values()))}
+
+    raise AttributeError(
+        "interaction.resolved did not have property `messages`, `members`, or `users`"
+    )

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -3,11 +3,7 @@ from __future__ import annotations
 from contextlib import suppress
 from typing import TYPE_CHECKING, Optional
 
-from hikari import (
-    UNDEFINED,
-    CommandInteraction,
-    Snowflake,
-)
+from hikari import UNDEFINED, CommandInteraction, Snowflake
 
 from crescent.context import Context
 from crescent.exceptions import CommandNotFoundError

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -1,33 +1,27 @@
 from __future__ import annotations
 
 from contextlib import suppress
-from copy import copy
 from typing import TYPE_CHECKING, Optional
 
 from hikari import (
     UNDEFINED,
     CommandInteraction,
-    CommandInteractionOption,
-    CommandType,
-    OptionType,
     Snowflake,
 )
 
 from crescent.context import Context
 from crescent.exceptions import CommandNotFoundError
 from crescent.internal.app_command import Unique
-from crescent.mentionable import Mentionable
 from crescent.utils.gather_iter import gather_iter
-from crescent.utils.options import unwrap
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Mapping, Sequence, cast
+    from typing import Any, Dict, Sequence, cast
 
-    from hikari import InteractionCreateEvent, Message, User
+    from hikari import InteractionCreateEvent
 
     from crescent.bot import Bot
     from crescent.internal import AppCommandMeta, MetaStruct
-    from crescent.typedefs import CommandCallbackT, OptionTypesT
+    from crescent.typedefs import CommandCallbackT
 
 
 __all__: Sequence = ("handle_resp",)
@@ -42,54 +36,31 @@ async def handle_resp(event: InteractionCreateEvent):
         interaction = cast(CommandInteraction, interaction)
         bot = cast(Bot, bot)
 
-    name: str = interaction.command_name
-    group: Optional[str] = None
-    sub_group: Optional[str] = None
-    options: Optional[Sequence[CommandInteractionOption]] = interaction.options
-
-    if options:
-        option = unwrap(options)[0]
-        if option.type == 1:
-            group = name
-            name = option.name
-            options = option.options
-        elif option.type == 2:
-            group = interaction.command_name
-            sub_group = option.name
-            name = unwrap(option.options)[0].name
-            options = unwrap(option.options)[0].options
-
-    command = _get_command(
-        bot, name, interaction.command_type, interaction.guild_id, group, sub_group
-    )
     ctx = Context._from_command_interaction(interaction)
-
-    callback_options: Mapping[str, OptionTypesT | Message | User]
-    if interaction.command_type is CommandType.SLASH:
-        callback_options = _options_to_kwargs(interaction, options)
-    else:
-        callback_options = _resolved_data_to_kwargs(interaction)
+    command = _get_command(
+        bot,
+        ctx.command,
+        int(ctx.command_type),
+        ctx.guild_id,
+        ctx.group,
+        ctx.sub_group,
+    )
 
     for hook in command.metadata.hooks:
-        hook_res = await hook(ctx, copy(callback_options))
+        hook_res = await hook(ctx)
 
-        if hook_res:
-            if hook_res.options:
-                callback_options = hook_res.options
-
-            if hook_res.exit:
-                break
+        if hook_res and hook_res.exit:
+            break
 
     else:
         try:
-            await command.callback(ctx, **callback_options)
+            await command.callback(ctx, **ctx.options)
         except Exception as e:
             if hdlrs := command.app._error_handler.registry.get(e.__class__):
                 await gather_iter(
                     func.callback(
                         exc=e,
                         ctx=ctx,
-                        options=callback_options,
                     )
                     for func in hdlrs
                 )
@@ -118,49 +89,3 @@ def _get_command(
     with suppress(KeyError):
         return bot._command_handler.registry[Unique(guild_id=UNDEFINED, **kwargs)]
     raise CommandNotFoundError(f"Handler for command `{name}` does not exist locally.")
-
-
-_VALUE_TYPE_LINK: Dict[OptionType | int, str] = {
-    OptionType.ROLE: "roles",
-    OptionType.USER: "users",
-    OptionType.CHANNEL: "channels",
-}
-
-
-def _options_to_kwargs(
-    interaction: CommandInteraction,
-    options: Optional[Sequence[CommandInteractionOption]],
-) -> Dict[str, Any]:
-    if not options:
-        return {}
-
-    return {option.name: _extract_value(option, interaction) for option in options}
-
-
-def _extract_value(option: CommandInteractionOption, interaction: CommandInteraction) -> Any:
-    if option.type is OptionType.MENTIONABLE:
-        return Mentionable._from_interaction(interaction)
-
-    resolved_type: Optional[str] = _VALUE_TYPE_LINK.get(option.type)
-
-    if resolved_type is None:
-        return option.value
-
-    resolved = getattr(interaction.resolved, resolved_type)
-    return resolved[option.value]
-
-
-def _resolved_data_to_kwargs(interaction: CommandInteraction) -> Dict[str, Message | User]:
-    if not interaction.resolved:
-        raise ValueError("interaction.resoved should be defined when running this function")
-
-    if interaction.resolved.messages:
-        return {"message": next(iter(interaction.resolved.messages.values()))}
-    if interaction.resolved.members:
-        return {"user": next(iter(interaction.resolved.members.values()))}
-    if interaction.resolved.users:
-        return {"user": next(iter(interaction.resolved.users.values()))}
-
-    raise AttributeError(
-        "interaction.resolved did not have property `messages`, `members`, or `users`"
-    )

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -34,12 +34,7 @@ async def handle_resp(event: InteractionCreateEvent):
 
     ctx = Context._from_command_interaction(interaction)
     command = _get_command(
-        bot,
-        ctx.command,
-        int(ctx.command_type),
-        ctx.guild_id,
-        ctx.group,
-        ctx.sub_group,
+        bot, ctx.command, int(ctx.command_type), ctx.guild_id, ctx.group, ctx.sub_group
     )
 
     for hook in command.metadata.hooks:
@@ -53,13 +48,7 @@ async def handle_resp(event: InteractionCreateEvent):
             await command.callback(ctx, **ctx.options)
         except Exception as e:
             if hdlrs := command.app._error_handler.registry.get(e.__class__):
-                await gather_iter(
-                    func.callback(
-                        exc=e,
-                        ctx=ctx,
-                    )
-                    for func in hdlrs
-                )
+                await gather_iter(func.callback(exc=e, ctx=ctx) for func in hdlrs)
             else:
                 raise
 

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -3,35 +3,30 @@ from __future__ import annotations
 from contextlib import suppress
 from typing import TYPE_CHECKING, Mapping, Optional, cast
 
-from hikari import (
-    UNDEFINED,
-    CommandType,
-    OptionType,
-)
+from hikari import UNDEFINED, CommandType, OptionType
 
 from crescent.context import Context
 from crescent.exceptions import CommandNotFoundError
 from crescent.internal.app_command import Unique
-from crescent.utils import gather_iter, unwrap
 from crescent.mentionable import Mentionable
+from crescent.utils import gather_iter, unwrap
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Sequence
 
     from hikari import (
-        InteractionCreateEvent,
         CommandInteraction,
         CommandInteractionOption,
+        InteractionCreateEvent,
         Message,
         Snowflake,
         User,
     )
 
     from crescent.bot import Bot
-    from crescent.internal import AppCommandMeta, MetaStruct
-    from crescent.typedefs import CommandCallbackT
     from crescent.context import RestAndCacheAware
-    from crescent.typedefs import OptionTypesT
+    from crescent.internal import AppCommandMeta, MetaStruct
+    from crescent.typedefs import CommandCallbackT, OptionTypesT
 
 
 __all__: Sequence = ("handle_resp",)
@@ -48,12 +43,7 @@ async def handle_resp(event: InteractionCreateEvent):
 
     ctx = _context_from_interaction_resp(interaction)
     command = _get_command(
-        bot,
-        ctx.command,
-        int(ctx.command_type),
-        ctx.guild_id,
-        ctx.group,
-        ctx.sub_group,
+        bot, ctx.command, int(ctx.command_type), ctx.guild_id, ctx.group, ctx.sub_group
     )
 
     for hook in command.metadata.hooks:
@@ -67,9 +57,7 @@ async def handle_resp(event: InteractionCreateEvent):
             await command.callback(ctx, **ctx.options)
         except Exception as e:
             if hdlrs := command.app._error_handler.registry.get(e.__class__):
-                await gather_iter(
-                    func.callback(exc=e, ctx=ctx) for func in hdlrs
-                )
+                await gather_iter(func.callback(exc=e, ctx=ctx) for func in hdlrs)
             else:
                 raise
 
@@ -83,21 +71,13 @@ def _get_command(
     sub_group: Optional[str],
 ) -> MetaStruct[CommandCallbackT, AppCommandMeta]:
 
-    kwargs: Dict[str, Any] = dict(
-        name=name, type=type, group=group, sub_group=sub_group
-    )
+    kwargs: Dict[str, Any] = dict(name=name, type=type, group=group, sub_group=sub_group)
 
     with suppress(KeyError):
-        return bot._command_handler.registry[
-            Unique(guild_id=guild_id, **kwargs)
-        ]
+        return bot._command_handler.registry[Unique(guild_id=guild_id, **kwargs)]
     with suppress(KeyError):
-        return bot._command_handler.registry[
-            Unique(guild_id=UNDEFINED, **kwargs)
-        ]
-    raise CommandNotFoundError(
-        f"Handler for command `{name}` does not exist locally."
-    )
+        return bot._command_handler.registry[Unique(guild_id=UNDEFINED, **kwargs)]
+    raise CommandNotFoundError(f"Handler for command `{name}` does not exist locally.")
 
 
 _VALUE_TYPE_LINK: Dict[OptionType | int, str] = {
@@ -150,20 +130,15 @@ def _context_from_interaction_resp(interaction: CommandInteraction) -> Context:
 
 
 def _options_to_kwargs(
-    interaction: CommandInteraction,
-    options: Optional[Sequence[CommandInteractionOption]],
+    interaction: CommandInteraction, options: Optional[Sequence[CommandInteractionOption]]
 ) -> Dict[str, Any]:
     if not options:
         return {}
 
-    return {
-        option.name: _extract_value(option, interaction) for option in options
-    }
+    return {option.name: _extract_value(option, interaction) for option in options}
 
 
-def _extract_value(
-    option: CommandInteractionOption, interaction: CommandInteraction
-) -> Any:
+def _extract_value(option: CommandInteractionOption, interaction: CommandInteraction) -> Any:
     if option.type is OptionType.MENTIONABLE:
         return Mentionable._from_interaction(interaction)
 
@@ -176,13 +151,9 @@ def _extract_value(
     return resolved[option.value]
 
 
-def _resolved_data_to_kwargs(
-    interaction: CommandInteraction,
-) -> Dict[str, Message | User]:
+def _resolved_data_to_kwargs(interaction: CommandInteraction) -> Dict[str, Message | User]:
     if not interaction.resolved:
-        raise ValueError(
-            "interaction.resoved should be defined when running this function"
-        )
+        raise ValueError("interaction.resoved should be defined when running this function")
 
     if interaction.resolved.messages:
         return {"message": next(iter(interaction.resolved.messages.values()))}

--- a/crescent/typedefs.py
+++ b/crescent/typedefs.py
@@ -34,7 +34,7 @@ OptionTypesT = Union[str, bool, int, float, PartialChannel, Role, User, "Mention
 UserCommandCallbackT = Callable[["Context", User], Awaitable[None]]
 MessageCommandCallbackT = Callable[["Context", Message], Awaitable[None]]
 CommandOptionsT = Dict[str, Union[OptionTypesT, User, Message]]
-HookCallbackT = Callable[["Context", CommandOptionsT], Awaitable[Optional["HookResult"]]]
+HookCallbackT = Callable[["Context"], Awaitable[Optional["HookResult"]]]
 
 
 class ClassCommandProto(Protocol):

--- a/examples/error_handling/basic.py
+++ b/examples/error_handling/basic.py
@@ -20,9 +20,8 @@ class RandomError3(Exception):
 async def on_random_error(
     exc: RandomError,
     ctx: crescent.Context,
-    options: crescent.CommandOptionsT,
 ) -> None:
-    await ctx.respond(f"{exc} raised!")
+    await ctx.respond(f"{exc} raised in {ctx.command}!")
 
 
 @bot.include
@@ -30,9 +29,8 @@ async def on_random_error(
 async def on_random_error_2(
     exc: Exception,
     ctx: crescent.Context,
-    options: crescent.CommandOptionsT,
 ) -> None:
-    await ctx.respond(f"{exc} raised!")
+    await ctx.respond(f"{exc} raised in {ctx.command}!")
 
 
 @bot.include

--- a/examples/error_handling/basic.py
+++ b/examples/error_handling/basic.py
@@ -17,19 +17,13 @@ class RandomError3(Exception):
 
 @bot.include
 @crescent.catch(RandomError)
-async def on_random_error(
-    exc: RandomError,
-    ctx: crescent.Context,
-) -> None:
+async def on_random_error(exc: RandomError, ctx: crescent.Context) -> None:
     await ctx.respond(f"{exc} raised in {ctx.command}!")
 
 
 @bot.include
 @crescent.catch(RandomError2, RandomError3)
-async def on_random_error_2(
-    exc: Exception,
-    ctx: crescent.Context,
-) -> None:
+async def on_random_error_2(exc: Exception, ctx: crescent.Context) -> None:
     await ctx.respond(f"{exc} raised in {ctx.command}!")
 
 

--- a/examples/hooks/group_hooks.py
+++ b/examples/hooks/group_hooks.py
@@ -7,15 +7,15 @@ import crescent
 bot = crescent.Bot(token="...")
 
 
-async def first_hook(ctx: crescent.Context, options: crescent.CommandOptionsT):
+async def first_hook(ctx: crescent.Context):
     print("Here first.")
 
 
-async def second_hook(ctx: crescent.Context, options: crescent.CommandOptionsT):
+async def second_hook(ctx: crescent.Context):
     print("Here second.")
 
 
-async def third_hook(ctx: crescent.Context, options: crescent.CommandOptionsT):
+async def third_hook(ctx: crescent.Context):
     print("Here third.")
 
 

--- a/examples/hooks/hooks.py
+++ b/examples/hooks/hooks.py
@@ -17,7 +17,7 @@ def second_hook(number: int) -> crescent.HookCallbackT:
     return inner
 
 
-bot = crescent.Bot(token="...")
+bot = crescent.Bot(token="Nzc4Mjg5NjE4ODc3MTUzMjgw.X7P0sQ.i0bxYnOttFSyHHqN6pyPOYNZi0g")
 
 
 @bot.include

--- a/examples/hooks/hooks.py
+++ b/examples/hooks/hooks.py
@@ -17,7 +17,7 @@ def second_hook(number: int) -> crescent.HookCallbackT:
     return inner
 
 
-bot = crescent.Bot(token="Nzc4Mjg5NjE4ODc3MTUzMjgw.X7P0sQ.i0bxYnOttFSyHHqN6pyPOYNZi0g")
+bot = crescent.Bot(token="...")
 
 
 @bot.include

--- a/examples/hooks/hooks.py
+++ b/examples/hooks/hooks.py
@@ -1,12 +1,7 @@
 import crescent
 
 
-async def first_hook(
-    ctx: crescent.Context,
-    # options is a shallow copy of the options from the interaction
-    options: crescent.CommandOptionsT,
-    # You can also return `None`
-) -> crescent.HookResult:
+async def first_hook(ctx: crescent.Context) -> crescent.HookResult:  # you can also return None
     print("Here first.")
     # Setting exit to true prevents any following hooks and the callback from
     # being run.
@@ -15,12 +10,9 @@ async def first_hook(
 
 
 def second_hook(number: int) -> crescent.HookCallbackT:
-    async def inner(
-        ctx: crescent.Context, options: crescent.CommandOptionsT
-    ) -> crescent.HookResult:
+    async def inner(ctx: crescent.Context) -> None:
         print(f"Here second. Number is {number}")
-        options["number"] = number
-        return crescent.HookResult(options=options)
+        ctx.options["numeber"] = number
 
     return inner
 


### PR DESCRIPTION
Fixes #37. Fixes #45 

Added the following options to `Context`:
 - options
 - command
 - group
 - sub_group
 - command_type

Removed the `options` kwarg from error and hook callbacks. They can use `ctx.options` instead.

Removed the `options` kwarg from `HookResult`. The can modify `ctx.options` directly instead.

I know you said you wanted them to not be able to modify ctx.options, but doing this adds overhead and complexity, both for us and for anyone using the lib. I think that if someone wants to modify options inside a hook, they should be allowed to do it directly. It doesn't have to be publicly supported.


I also fixed the `hook` decorator. Apparently that wasn't typehinted right, so I wasn't able to find it earlier when I moved `MetaStruct.interaction_hooks` to `AppCommandMeta.hooks`.