### PR TITLE
:sparkles: Add catch-all error handler

### DIFF
--- a/crescent/bot.py
+++ b/crescent/bot.py
@@ -148,4 +148,4 @@ class Bot(GatewayBot):
         except Exception:
             pass
         print(f"Unhandled exception occurred in the command {ctx.command}:")
-        traceback.print_exception(exc.__class__, exc, exc.__traceback__)
+        print_exception(exc.__class__, exc, exc.__traceback__)

--- a/crescent/bot.py
+++ b/crescent/bot.py
@@ -144,7 +144,7 @@ class Bot(GatewayBot):
         if was_handled:
             return
         try:
-            await ctx.respond("An unexpected error occured.", ephemeral=True)
+            await ctx.respond("An unexpected error occurred.", ephemeral=True)
         except Exception:
             pass
         print(f"Unhandled exception occured in the command {ctx.command}:")

--- a/crescent/bot.py
+++ b/crescent/bot.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from traceback import print_exception
 from concurrent.futures import Executor
 from itertools import chain
+from traceback import print_exception
 from typing import TYPE_CHECKING, Callable, Sequence, overload
 
 from hikari import (

--- a/crescent/bot.py
+++ b/crescent/bot.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import traceback
 from concurrent.futures import Executor
 from itertools import chain
-import traceback
 from typing import TYPE_CHECKING, Callable, Sequence, overload
 
 from hikari import (

--- a/crescent/bot.py
+++ b/crescent/bot.py
@@ -147,5 +147,5 @@ class Bot(GatewayBot):
             await ctx.respond("An unexpected error occurred.", ephemeral=True)
         except Exception:
             pass
-        print(f"Unhandled exception occured in the command {ctx.command}:")
+        print(f"Unhandled exception occurred in the command {ctx.command}:")
         traceback.print_exception(exc.__class__, exc, exc.__traceback__)

--- a/crescent/bot.py
+++ b/crescent/bot.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import traceback
+from traceback import print_exception
 from concurrent.futures import Executor
 from itertools import chain
 from typing import TYPE_CHECKING, Callable, Sequence, overload

--- a/crescent/bot.py
+++ b/crescent/bot.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from concurrent.futures import Executor
 from itertools import chain
+import traceback
 from typing import TYPE_CHECKING, Callable, Sequence, overload
 
 from hikari import (
@@ -24,6 +25,8 @@ from crescent.utils import iterate_vars
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Optional, TypeVar, Union
+
+    from crescent.context import Context
 
     META_STRUCT = TypeVar("META_STRUCT", bound=MetaStruct)
 
@@ -136,3 +139,13 @@ class Bot(GatewayBot):
         plugin = Plugin._from_module(path)
         self.add_plugin(plugin)
         return plugin
+
+    async def on_crescent_error(self, exc: Exception, ctx: Context, was_handled: bool) -> None:
+        if was_handled:
+            return
+        try:
+            await ctx.respond("An unexpected error occured.", ephemeral=True)
+        except Exception:
+            pass
+        print(f"Unhandled exception occured in the command {ctx.command}:")
+        traceback.print_exception(exc.__class__, exc, exc.__traceback__)

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -58,8 +58,11 @@ async def handle_resp(event: InteractionCreateEvent):
         except Exception as e:
             if func := command.app._error_handler.registry.get(e.__class__):
                 await func.callback(e, ctx)
+                handled = True
             else:
-                raise
+                handled = False
+
+            await bot.on_crescent_error(e, ctx, handled)
 
 
 def _get_command(

--- a/examples/error_handling/basic.py
+++ b/examples/error_handling/basic.py
@@ -15,6 +15,10 @@ class RandomError3(Exception):
     pass
 
 
+class UnhandledError(Exception):
+    pass
+
+
 @bot.include
 @crescent.catch(RandomError)
 async def on_random_error(exc: RandomError, ctx: crescent.Context) -> None:
@@ -31,6 +35,12 @@ async def on_random_error_2(exc: Exception, ctx: crescent.Context) -> None:
 @crescent.command
 async def raise_error(ctx: crescent.Context):
     raise RandomError("Lol")
+
+
+@bot.include
+@crescent.command
+async def raise_unhandled_error(ctx: crescent.Context):
+    raise UnhandledError("oops...")
 
 
 bot.run()


### PR DESCRIPTION
Fixes #60 

I went with  f"Unhandled exception occured in the command {ctx.command}:"