### PR TITLE
:technologist: make merging docs merge correctly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/* merge=ours


### PR DESCRIPTION
It doesn't matter how docs merge since they will always be generated corrected by CI. This should remove annoying merge conflicts.