### PR TITLE
:sparkles: Add plugin load and unload hook

### DIFF
--- a/crescent/errors.py
+++ b/crescent/errors.py
@@ -29,7 +29,10 @@ def _make_catch_function(
 
         def decorator(callback: T) -> MetaStruct[T, Any]:
             meta = MetaStruct(
-                callback, None, app_set_hooks=[app_set_hook], plugin_unload_hook=plugin_unload_hook
+                callback,
+                None,
+                app_set_hooks=[app_set_hook],
+                plugin_unload_hooks=[plugin_unload_hook],
             )
 
             return meta

--- a/crescent/errors.py
+++ b/crescent/errors.py
@@ -23,7 +23,7 @@ def _make_catch_function(
             for exc in exceptions:
                 getattr(meta.app, error_handler_var).register(meta, exc)
 
-        def plugin_unload_hook(meta: MetaStruct[T, Any]):
+        def plugin_unload_hook(meta: MetaStruct[T, Any]) -> None:
             for exc in exceptions:
                 getattr(meta.app, error_handler_var).remove(exc)
 
@@ -51,8 +51,7 @@ _catch_autocomplete = _make_catch_function("_autocomplete_error_handler")
 def catch_command(
     *exceptions: Type[Exception],
 ) -> Callable[
-    [CommandErrorHandlerCallbackT[Any] | MetaStruct[CommandErrorHandlerCallbackT[Any], Any]],
-    MetaStruct[CommandErrorHandlerCallbackT[Any], Any],
+    [CommandErrorHandlerCallbackT[Any]], MetaStruct[CommandErrorHandlerCallbackT[Any], Any],
 ]:
     return _catch_command(*exceptions)
 
@@ -60,8 +59,7 @@ def catch_command(
 def catch_event(
     *exceptions: Type[Exception],
 ) -> Callable[
-    [EventErrorHandlerCallbackT[Any] | MetaStruct[EventErrorHandlerCallbackT[Any], Any]],
-    MetaStruct[EventErrorHandlerCallbackT[Any], Any],
+    [EventErrorHandlerCallbackT[Any]], MetaStruct[EventErrorHandlerCallbackT[Any], Any],
 ]:
     return _catch_event(*exceptions)
 
@@ -69,10 +67,7 @@ def catch_event(
 def catch_autocomplete(
     *exceptions: Type[Exception],
 ) -> Callable[
-    [
-        AutocompleteErrorHandlerCallbackT[Any]
-        | MetaStruct[AutocompleteErrorHandlerCallbackT[Any], Any]
-    ],
+    [AutocompleteErrorHandlerCallbackT[Any]],
     MetaStruct[AutocompleteErrorHandlerCallbackT[Any], Any],
 ]:
     return _catch_autocomplete(*exceptions)

--- a/crescent/event.py
+++ b/crescent/event.py
@@ -52,7 +52,7 @@ def event(
         meta.app.unsubscribe(event_type=unwrap(event_type), callback=event_callback)
 
     meta = MetaStruct(
-        callback=callback, metadata=None, app_set_hooks=[hook], plugin_unload_hook=on_remove
+        callback=callback, metadata=None, app_set_hooks=[hook], plugin_unload_hooks=[on_remove]
     )
     event_callback = _event_callback(meta)
 

--- a/crescent/exceptions.py
+++ b/crescent/exceptions.py
@@ -1,6 +1,10 @@
 from typing import Sequence
 
-__all__: Sequence[str] = ("CrescentException", "AlreadyRegisteredError")
+__all__: Sequence[str] = (
+    "CrescentException",
+    "AlreadyRegisteredError",
+    "PluginAlreadyLoadedError",
+)
 
 
 class CrescentException(Exception):
@@ -9,3 +13,7 @@ class CrescentException(Exception):
 
 class AlreadyRegisteredError(CrescentException):
     """Command or exception catch function was already registered"""
+
+
+class PluginAlreadyLoadedError(CrescentException):
+    """A plugin is attempted to be loaded but the plugin manager already loaded the plugin."""

--- a/crescent/internal/meta_struct.py
+++ b/crescent/internal/meta_struct.py
@@ -27,6 +27,7 @@ class MetaStruct(Generic[T, U]):
     _app: Optional[Bot] = None
 
     app_set_hooks: List[Callable[[MetaStruct[T, U]], None]] = field(factory=list)
+    plugin_unload_hook: Callable[[MetaStruct[T, U]], None] | None = None
 
     @property
     def app(self) -> Bot:

--- a/crescent/internal/meta_struct.py
+++ b/crescent/internal/meta_struct.py
@@ -27,7 +27,7 @@ class MetaStruct(Generic[T, U]):
     _app: Optional[Bot] = None
 
     app_set_hooks: List[Callable[[MetaStruct[T, U]], None]] = field(factory=list)
-    plugin_unload_hook: Callable[[MetaStruct[T, U]], None] | None = None
+    plugin_unload_hooks: List[Callable[[MetaStruct[T, U]], None]] = field(factory=list)
 
     @property
     def app(self) -> Bot:

--- a/crescent/internal/meta_struct.py
+++ b/crescent/internal/meta_struct.py
@@ -27,7 +27,7 @@ class MetaStruct(Generic[T, U]):
     _app: Optional[Bot] = None
 
     app_set_hooks: List[Callable[[MetaStruct[T, U]], None]] = field(factory=list)
-    plugin_unload_hooks: List[Callable[[MetaStruct[T, U]], None]] = field(factory=list)
+    plugin_unload_hooks: list[Callable[[MetaStruct[T, U]], None]] = field(factory=list)
 
     @property
     def app(self) -> Bot:

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -94,7 +94,7 @@ class ErrorHandler(Generic[_E]):
 
         self.registry[exc] = meta
 
-    def remove(self, exc: Type[Exception]):
+    def remove(self, exc: Type[Exception]) -> None:
         self.registry.pop(exc)
 
     async def try_handle(self, exc: Exception, args: Sequence[Any]) -> bool:

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -54,7 +54,7 @@ def register_command(
     meta: MetaStruct[T, AppCommandMeta] = MetaStruct(
         callback=callback,
         app_set_hooks=[_command_app_set_hook],
-        plugin_unload_hook=_plugin_unload_callback,
+        plugin_unload_hooks=[_plugin_unload_callback],
         metadata=AppCommandMeta(
             deprecated=deprecated,
             autocomplete=autocomplete,

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -15,7 +15,7 @@ from crescent.internal.meta_struct import MetaStruct
 from crescent.utils import gather_iter, unwrap
 
 if TYPE_CHECKING:
-    from typing import Any, Awaitable, Callable, DefaultDict, Dict, List, Optional, Sequence, Type
+    from typing import Any, Awaitable, Callable, DefaultDict, List, Optional, Sequence, Type
 
     from hikari import Snowflakeish, UndefinedOr
 
@@ -45,7 +45,7 @@ def register_command(
     options: Optional[Sequence[CommandOption]] = None,
     default_permission: UndefinedOr[bool] = UNDEFINED,
     deprecated: bool = False,
-    autocomplete: Dict[str, AutocompleteCallbackT] = {},
+    autocomplete: dict[str, AutocompleteCallbackT] = {},
 ) -> MetaStruct[T, AppCommandMeta]:
 
     if not iscoroutinefunction(callback):
@@ -80,7 +80,7 @@ class ErrorHandler(Generic[_E]):
 
     def __init__(self, bot: Bot):
         self.bot = bot
-        self.registry: Dict[Type[Exception], MetaStruct[_E, Any]] = dict()
+        self.registry: dict[Type[Exception], MetaStruct[_E, Any]] = dict()
 
     def register(self, meta: MetaStruct[_E, Any], exc: Type[Exception]) -> None:
         if reg_meta := self.registry.get(exc):
@@ -116,7 +116,7 @@ class CommandHandler:
         self.guilds: Sequence[Snowflakeish] = guilds
         self.application_id: Optional[Snowflake] = None
 
-        self.registry: Dict[
+        self.registry: dict[
             Unique, MetaStruct["Callable[..., Awaitable[Any]]", AppCommandMeta]
         ] = dict()
 
@@ -133,7 +133,7 @@ class CommandHandler:
 
     def build_commands(self) -> Sequence[AppCommand]:
 
-        built_commands: Dict[Unique, AppCommand] = {}
+        built_commands: dict[Unique, AppCommand] = {}
 
         for command in self.registry.values():
             if command.metadata.deprecated:

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 from inspect import iscoroutinefunction
 from logging import getLogger
 from typing import TYPE_CHECKING, Generic, TypeVar, cast
-from weakref import WeakValueDictionary
 
 from hikari import UNDEFINED, CommandOption, CommandType, ForbiddenError, OptionType, Snowflake
 from hikari.api import CommandBuilder
@@ -29,6 +28,14 @@ if TYPE_CHECKING:
 _log = getLogger(__name__)
 
 
+def _plugin_unload_callback(self: MetaStruct[Any, Any]) -> None:
+    self.app._command_handler.remove(self)
+
+
+def _command_app_set_hook(self: MetaStruct[T, AppCommandMeta]) -> None:
+    self.app._command_handler.register(self)
+
+
 def register_command(
     callback: T,
     command_type: CommandType,
@@ -44,12 +51,10 @@ def register_command(
     if not iscoroutinefunction(callback):
         raise ValueError(f"`{callback.__name__}` must be an async function.")
 
-    def hook(self: MetaStruct[T, AppCommandMeta]) -> None:
-        self.app._command_handler.register(self)
-
     meta: MetaStruct[T, AppCommandMeta] = MetaStruct(
         callback=callback,
-        app_set_hooks=[hook],
+        app_set_hooks=[_command_app_set_hook],
+        plugin_unload_hook=_plugin_unload_callback,
         metadata=AppCommandMeta(
             deprecated=deprecated,
             autocomplete=autocomplete,
@@ -75,9 +80,9 @@ class ErrorHandler(Generic[_E]):
 
     def __init__(self, bot: Bot):
         self.bot = bot
-        self.registry: WeakValueDictionary[
+        self.registry: Dict[
             Type[Exception], MetaStruct[_E, Any]
-        ] = WeakValueDictionary()
+        ] = dict()
 
     def register(self, meta: MetaStruct[_E, Any], exc: Type[Exception]) -> None:
         if reg_meta := self.registry.get(exc):
@@ -88,6 +93,9 @@ class ErrorHandler(Generic[_E]):
             )
 
         self.registry[exc] = meta
+
+    def remove(self, exc: Type[Exception]):
+        self.registry.pop(exc)
 
     async def try_handle(self, exc: Exception, args: Sequence[Any]) -> bool:
         """
@@ -110,9 +118,9 @@ class CommandHandler:
         self.guilds: Sequence[Snowflakeish] = guilds
         self.application_id: Optional[Snowflake] = None
 
-        self.registry: WeakValueDictionary[
+        self.registry: Dict[
             Unique, MetaStruct["Callable[..., Awaitable[Any]]", AppCommandMeta]
-        ] = WeakValueDictionary()
+        ] = dict()
 
     def register(self, command: MetaStruct[T, AppCommandMeta]) -> MetaStruct[T, AppCommandMeta]:
         command.metadata.app.guild_id = command.metadata.app.guild_id or self.bot.default_guild
@@ -121,6 +129,9 @@ class CommandHandler:
         _command = cast("MetaStruct[Callable[..., Awaitable[Any]], AppCommandMeta]", command)
         self.registry[command.metadata.unique] = _command
         return command
+
+    def remove(self, command: MetaStruct[T, AppCommandMeta]) -> None:
+        self.registry.pop(command.metadata.unique)
 
     def build_commands(self) -> Sequence[AppCommand]:
 

--- a/crescent/plugin.py
+++ b/crescent/plugin.py
@@ -56,7 +56,6 @@ class PluginManager:
             old_plugin._unload()
 
         plugin = Plugin._from_module(path, refresh=refresh)
-
         self._add_plugin(path, plugin, refresh=refresh)
 
         return plugin
@@ -66,7 +65,6 @@ class PluginManager:
             raise ValueError(f"Plugin {plugin.path} is already loaded.")
 
         self.plugins[path] = plugin
-
         plugin._load(self._bot)
 
 

--- a/crescent/plugin.py
+++ b/crescent/plugin.py
@@ -29,7 +29,7 @@ class PluginManager:
     def add_plugin(self, plugin: Plugin, force: bool = False) -> None:
         _log.warning("`add_plugin` is deprecated and will be removed in a future release.")
 
-        self._add_plugin(self, plugin, force=force)
+        self._add_plugin(plugin, force=force)
 
     def unload(self, name: str) -> None:
         plugin = self.plugins.pop(name)

--- a/crescent/plugin.py
+++ b/crescent/plugin.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
     from crescent.typedefs import HookCallbackT, PluginCallbackT
 
-    from .bot import Bot
+    from crescent.bot import Bot
 
     T = TypeVar("T", bound="MetaStruct[Any, Any]")
 
@@ -53,7 +53,7 @@ class PluginManager:
 
         Args:
             path: The module path for the plugin.
-            refresh: Whether or not to reload the plugin.
+            refresh: Whether or not to reload the plugin's module.
         """
 
         plugin = Plugin._from_module(path, refresh=refresh)

--- a/crescent/plugin.py
+++ b/crescent/plugin.py
@@ -62,7 +62,7 @@ class PluginManager:
 
     def _add_plugin(self, path: str, plugin: Plugin, refresh: bool = False) -> None:
         if path in self.plugins and not refresh:
-            raise ValueError(f"Plugin {plugin.path} is already loaded.")
+            raise ValueError(f"Plugin {path} is already loaded.")
 
         self.plugins[path] = plugin
         plugin._load(self._bot)

--- a/crescent/plugin.py
+++ b/crescent/plugin.py
@@ -55,7 +55,7 @@ class PluginManager:
         """
 
         if refresh:
-            old_plugin = self.plugins.pop(path, None)
+            old_plugin = self.plugins.pop(path)
             old_plugin._unload()
 
         plugin = Plugin._from_module(path, refresh=refresh)

--- a/crescent/plugin.py
+++ b/crescent/plugin.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 __all__: Sequence[str] = ("PluginManager", "Plugin")
 
-_log = getLogger(__name__)
+_LOG = getLogger(__name__)
 
 
 class PluginManager:
@@ -27,7 +27,7 @@ class PluginManager:
         self._bot = bot
 
     def add_plugin(self, plugin: Plugin, force: bool = False) -> None:
-        _log.warning("`add_plugin` is deprecated and will be removed in a future release.")
+        _LOG.warning("`add_plugin` is deprecated and will be removed in a future release.")
 
         self._add_plugin(plugin, force=force)
 

--- a/crescent/plugin.py
+++ b/crescent/plugin.py
@@ -38,8 +38,8 @@ class PluginManager:
             callback()
 
         for child in plugin._children:
-            if child.plugin_unload_hook:
-                child.plugin_unload_hook(child)
+            for hook in child.plugin_unload_hooks:
+                hook(child)
 
     def load(self, path: str, refresh: bool = False) -> Plugin:
         """Load a plugin from the module path.

--- a/crescent/plugin.py
+++ b/crescent/plugin.py
@@ -31,8 +31,8 @@ class PluginManager:
 
         self._add_plugin("", plugin, refresh=force)
 
-    def unload(self, name: str) -> None:
-        plugin = self.plugins.pop(name)
+    def unload(self, path: str) -> None:
+        plugin = self.plugins.pop(path)
         plugin._unload()
 
     def load(self, path: str, refresh: bool = False) -> Plugin:

--- a/crescent/plugin.py
+++ b/crescent/plugin.py
@@ -8,6 +8,7 @@ import hikari
 
 from crescent.internal.meta_struct import MetaStruct
 from crescent.utils import add_hooks
+from crescent.exceptions import PluginAlreadyLoadedError
 
 if TYPE_CHECKING:
     from typing import Any, Sequence, TypeVar
@@ -54,7 +55,7 @@ class PluginManager:
         """
 
         if refresh:
-            old_plugin = self.plugins.pop(path)
+            old_plugin = self.plugins.pop(path, None)
             old_plugin._unload()
 
         plugin = Plugin._from_module(path, refresh=refresh)
@@ -64,7 +65,10 @@ class PluginManager:
 
     def _add_plugin(self, path: str, plugin: Plugin, refresh: bool = False) -> None:
         if path in self.plugins and not refresh:
-            raise ValueError(f"Plugin {path} is already loaded.")
+            raise PluginAlreadyLoadedError(
+                f"Plugin `{path}` is already loaded."
+                " Add the kwarg `refresh=True` to the function call if this is intended."
+            )
 
         self.plugins[path] = plugin
         plugin._load(self._bot)

--- a/crescent/plugin.py
+++ b/crescent/plugin.py
@@ -29,17 +29,11 @@ class PluginManager:
     def add_plugin(self, plugin: Plugin, force: bool = False) -> None:
         _LOG.warning("`add_plugin` is deprecated and will be removed in a future release.")
 
-        self._add_plugin(plugin, force=force)
+        self._add_plugin(plugin, refresh=force)
 
     def unload(self, name: str) -> None:
         plugin = self.plugins.pop(name)
-
-        for callback in plugin._unload_hooks:
-            callback()
-
-        for child in plugin._children:
-            for hook in child.plugin_unload_hooks:
-                hook(child)
+        plugin._unload()
 
     def load(self, path: str, refresh: bool = False) -> Plugin:
         """Load a plugin from the module path.
@@ -54,23 +48,27 @@ class PluginManager:
 
         Args:
             path: The module path for the plugin.
-            refresh: Whether or not to reload the plugin's module.
+            refresh: Whether or not to reload the plugin and the plugin's module.
         """
 
-        plugin = Plugin._from_module(path, refresh=refresh)
-        self._add_plugin(plugin, force=refresh)
+        new_plugin = Plugin._from_module(path, refresh=refresh)
 
-        for callback in plugin._load_hooks:
-            callback()
+        if refresh:
+            old_plugin = self.plugins.pop(new_plugin.name)
+            old_plugin._unload()
 
-        return plugin
+        self._add_plugin(new_plugin, refresh=refresh)
 
-    def _add_plugin(self, plugin: Plugin, force: bool = False) -> None:
+        return new_plugin
+
+    def _add_plugin(self, plugin: Plugin, refresh: bool = False, path: str = None) -> None:
         if plugin.name in self.plugins:
-            if not force:
+            if not refresh:
                 raise ValueError(f"Plugin name {plugin.name} already exists.")
+
         self.plugins[plugin.name] = plugin
-        plugin._setup(self._bot)
+
+        plugin._load(self._bot)
 
 
 class Plugin:
@@ -99,10 +97,21 @@ class Plugin:
     def unload_hook(self, callback: PluginCallbackT) -> None:
         self._unload_hooks.append(callback)
 
-    def _setup(self, bot: Bot) -> None:
-        for item in self._children:
-            add_hooks(bot, item)
-            item.register_to_app(bot)
+    def _load(self, bot: Bot) -> None:
+        for callback in self._load_hooks:
+            callback()
+        for child in self._children:
+            add_hooks(bot, child)
+            child.register_to_app(bot)
+
+    def _unload(self) -> None:
+        for callback in self._unload_hooks:
+            callback()
+
+        for child in self._children:
+            print(child._app)
+            for hook in child.plugin_unload_hooks:
+                hook(child)
 
     @classmethod
     def _from_module(cls, path: str, refresh: bool = False) -> Plugin:

--- a/crescent/plugin.py
+++ b/crescent/plugin.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from importlib import import_module, reload
 from logging import getLogger
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING
 
 import hikari
 
@@ -26,7 +26,7 @@ _LOG = getLogger(__name__)
 
 class PluginManager:
     def __init__(self, bot: Bot) -> None:
-        self.plugins: Dict[str, Plugin] = {}
+        self.plugins: dict[str, Plugin] = {}
         self._bot = bot
 
     def add_plugin(self, plugin: Plugin, force: bool = False) -> None:
@@ -89,7 +89,7 @@ class Plugin:
 
         self.command_hooks = command_hooks
         self.command_after_hooks = command_after_hooks
-        self._app: Optional[Bot] = None
+        self._app: Bot | None = None
         self._children: list[MetaStruct[Any, Any]] = []
 
         self._load_hooks: list[PluginCallbackT] = []

--- a/crescent/plugin.py
+++ b/crescent/plugin.py
@@ -61,7 +61,7 @@ class PluginManager:
 
         return new_plugin
 
-    def _add_plugin(self, plugin: Plugin, refresh: bool = False, path: str = None) -> None:
+    def _add_plugin(self, plugin: Plugin, refresh: bool = False) -> None:
         if plugin.name in self.plugins:
             if not refresh:
                 raise ValueError(f"Plugin name {plugin.name} already exists.")

--- a/crescent/typedefs.py
+++ b/crescent/typedefs.py
@@ -24,7 +24,6 @@ from hikari import (
 )
 
 if TYPE_CHECKING:
-    from crescent.bot import Bot
     from crescent.commands.hooks import HookResult
     from crescent.context import Context
     from crescent.mentionable import Mentionable
@@ -52,7 +51,7 @@ AutocompleteCallbackT = Callable[
     ["Context", AutocompleteInteractionOption], Awaitable[Sequence[CommandChoice]]
 ]
 
-PluginCallbackT = Callable[["Bot"], None]
+PluginCallbackT = Callable[[], None]
 
 
 class ClassCommandProto(Protocol):

--- a/crescent/typedefs.py
+++ b/crescent/typedefs.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from crescent.commands.hooks import HookResult
     from crescent.context import Context
     from crescent.mentionable import Mentionable
+    from crescent.bot import Bot
 
 __all__: Sequence[str] = (
     "CommandCallbackT",
@@ -50,6 +51,8 @@ HookCallbackT = Callable[["Context"], Awaitable[Optional["HookResult"]]]
 AutocompleteCallbackT = Callable[
     ["Context", AutocompleteInteractionOption], Awaitable[Sequence[CommandChoice]]
 ]
+
+PluginCallbackT = Callable[["Bot"], None]
 
 
 class ClassCommandProto(Protocol):

--- a/examples/plugins/example.py
+++ b/examples/plugins/example.py
@@ -6,7 +6,10 @@ bot.plugins.load("plugin")
 bot.plugins.load("folder.another_plugin")
 
 # Plugins can be unloaded and reloaded
-bot.plugins.unload("example")  # Uses plugin name
-bot.plugins.load("plugin")  # Uses plugin path
+bot.plugins.unload("plugin")
+bot.plugins.load("plugin")
+
+bot.plugins.unload("folder.another_plugin")
+bot.plugins.load("folder.another_plugin")
 
 bot.run()

--- a/examples/plugins/example.py
+++ b/examples/plugins/example.py
@@ -5,4 +5,8 @@ bot = crescent.Bot(token="TOKEN")
 bot.plugins.load("plugin")
 bot.plugins.load("folder.another_plugin")
 
+# Plugins can be unloaded and reloaded
+bot.plugins.unload("example")  # Uses plugin name
+bot.plugins.load("plugin")  # Uses plugin path
+
 bot.run()

--- a/examples/plugins/folder/another_plugin.py
+++ b/examples/plugins/folder/another_plugin.py
@@ -1,9 +1,9 @@
 import crescent
 
-plugin = crescent.Plugin("another one?")
+plugin = crescent.Plugin()
 
 
 @plugin.include
 @crescent.command
 async def nested_plugin(ctx: crescent.Context):
-    await ctx.respond("yup.")
+    await ctx.respond("Working!")

--- a/examples/plugins/plugin.py
+++ b/examples/plugins/plugin.py
@@ -25,6 +25,7 @@ def on_load():
     print("LOADED")
 
 
+# Unload is automatically called when the bot is closed (hikari.StoppedEvent)
 @plugin.unload_hook
-def on_load():
+def on_unload():
     print("UNLOADED")

--- a/examples/plugins/plugin.py
+++ b/examples/plugins/plugin.py
@@ -25,7 +25,7 @@ def on_load():
     print("LOADED")
 
 
-# Unload is automatically called when the bot is closed (hikari.StoppedEvent)
+# Unload hooks are automatically called when the bot is shut down (hikari.StoppedEvent)
 @plugin.unload_hook
 def on_unload():
     print("UNLOADED")

--- a/examples/plugins/plugin.py
+++ b/examples/plugins/plugin.py
@@ -2,7 +2,7 @@ import hikari
 
 import crescent
 
-plugin = crescent.Plugin("example")
+plugin = crescent.Plugin()
 
 
 @plugin.include

--- a/examples/plugins/plugin.py
+++ b/examples/plugins/plugin.py
@@ -15,3 +15,16 @@ async def plugin_command(ctx):
 @crescent.event
 async def plugin_event(event: hikari.MessageCreateEvent):
     print("plugin event triggered")
+
+
+# You can run functions when a plugin is loaded and unloaded
+
+
+@plugin.load_hook
+def on_load():
+    print("LOADED")
+
+
+@plugin.unload_hook
+def on_load():
+    print("UNLOADED")

--- a/tests/crescent/plugins/hook_plugin.py
+++ b/tests/crescent/plugins/hook_plugin.py
@@ -2,11 +2,11 @@ import crescent
 
 
 class HookPlugin(crescent.Plugin):
-    def __init__(self, name: str) -> None:
+    def __init__(self) -> None:
         self.loaded_hook_run_count = 0
         self.unloaded_hook_run_count = 0
 
-        super().__init__(name)
+        super().__init__()
 
 
 plugin = HookPlugin()

--- a/tests/crescent/plugins/hook_plugin.py
+++ b/tests/crescent/plugins/hook_plugin.py
@@ -9,7 +9,7 @@ class HookPlugin(crescent.Plugin):
         super().__init__(name)
 
 
-plugin = HookPlugin("test-plugin")
+plugin = HookPlugin()
 
 
 @plugin.load_hook

--- a/tests/crescent/plugins/plugin.py
+++ b/tests/crescent/plugins/plugin.py
@@ -1,5 +1,24 @@
 # This plugin is loaded by the `test_plugins.py` tests
 
-from crescent import Plugin
+from hikari import MessageCreateEvent
+from crescent import Plugin, event, catch_command, command, Context
 
-plugin = Plugin("example")
+plugin = Plugin("test-plugin")
+
+
+@plugin.include
+@command
+async def plugin_command(ctx: Context):
+    ...
+
+
+@plugin.include
+@event
+async def plugin_event(event: MessageCreateEvent):
+    ...
+
+
+@plugin.include
+@catch_command(Exception)
+async def plugin_catch_command(exc: Exception, ctx: Context):
+    ...

--- a/tests/crescent/plugins/plugin.py
+++ b/tests/crescent/plugins/plugin.py
@@ -4,7 +4,7 @@ from hikari import MessageCreateEvent
 
 from crescent import Context, Plugin, catch_command, command, event
 
-plugin = Plugin("test-plugin")
+plugin = Plugin()
 
 
 @plugin.include

--- a/tests/crescent/plugins/test_plugins.py
+++ b/tests/crescent/plugins/test_plugins.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from hikari import MessageCreateEvent
+from pytest import raises
+from crescent.exceptions import PluginAlreadyLoadedError
 
 from tests.crescent.plugins.plugin import (
     plugin,
@@ -89,3 +91,11 @@ class TestPlugins:
         assert plugin._app is not None
         bot.plugins.unload("tests.crescent.plugins.plugin")
         assert plugin._app is None
+
+    def test_load_twice(self):
+        bot = MockBot()
+
+        bot.plugins.load("tests.crescent.plugins.plugin")
+
+        with raises(PluginAlreadyLoadedError):
+            bot.plugins.load("tests.crescent.plugins.plugin")

--- a/tests/crescent/plugins/test_plugins.py
+++ b/tests/crescent/plugins/test_plugins.py
@@ -70,3 +70,14 @@ class TestPlugins:
 
         assert orig is orig2
         assert orig is not new
+
+    def test_load_hook(self):
+        bot = MockBot()
+
+        plugin = bot.plugins.load("tests.crescent.plugins.hook_plugin")
+        assert plugin.loaded_hook_run_count == 1
+        assert plugin.unloaded_hook_run_count == 0
+
+        bot.plugins.unload("test-plugin")
+        assert plugin.loaded_hook_run_count == 1
+        assert plugin.unloaded_hook_run_count == 1

--- a/tests/crescent/plugins/test_plugins.py
+++ b/tests/crescent/plugins/test_plugins.py
@@ -33,7 +33,7 @@ class TestPlugins:
         bot = MockBot()
 
         bot.plugins.load("tests.crescent.plugins.plugin")
-        bot.plugins.unload("test-plugin")
+        bot.plugins.unload("tests.crescent.plugins.plugin")
 
         assert plugin_command.metadata.unique not in bot._command_handler.registry
         assert len(bot._event_manager.get_listeners(MessageCreateEvent)) == 0
@@ -43,7 +43,7 @@ class TestPlugins:
         bot = MockBot()
 
         bot.plugins.load("tests.crescent.plugins.plugin")
-        bot.plugins.unload("test-plugin")
+        bot.plugins.unload("tests.crescent.plugins.plugin")
         _plugin = bot.plugins.load("tests.crescent.plugins.plugin")
 
         assert _plugin is plugin
@@ -61,7 +61,7 @@ class TestPlugins:
         bot = MockBot()
 
         orig = bot.plugins.load("tests.crescent.plugins.plugin")
-        bot.plugins.unload("test-plugin")
+        bot.plugins.unload("tests.crescent.plugins.plugin")
 
         orig2 = bot.plugins.load("tests.crescent.plugins.plugin")
 
@@ -78,6 +78,6 @@ class TestPlugins:
         assert plugin.loaded_hook_run_count == 1
         assert plugin.unloaded_hook_run_count == 0
 
-        bot.plugins.unload("test-plugin")
+        bot.plugins.unload("tests.crescent.plugins.hook_plugin")
         assert plugin.loaded_hook_run_count == 1
         assert plugin.unloaded_hook_run_count == 1

--- a/tests/crescent/plugins/test_plugins.py
+++ b/tests/crescent/plugins/test_plugins.py
@@ -64,8 +64,8 @@ class TestPlugins:
         bot.plugins.unload("test-plugin")
 
         orig2 = bot.plugins.load("tests.crescent.plugins.plugin")
-        bot.plugins.unload("test-plugin")
 
+        # Calling refresh should automatically unload the plugin.
         new = bot.plugins.load("tests.crescent.plugins.plugin", refresh=True)
 
         assert orig is orig2

--- a/tests/crescent/plugins/test_plugins.py
+++ b/tests/crescent/plugins/test_plugins.py
@@ -81,3 +81,11 @@ class TestPlugins:
         bot.plugins.unload("tests.crescent.plugins.hook_plugin")
         assert plugin.loaded_hook_run_count == 1
         assert plugin.unloaded_hook_run_count == 1
+
+    def test_app_set(self):
+        bot = MockBot()
+
+        plugin = bot.plugins.load("tests.crescent.plugins.plugin")
+        assert plugin._app is not None
+        bot.plugins.unload("tests.crescent.plugins.plugin")
+        assert plugin._app is None

--- a/tests/test_bot/test_plugin.py
+++ b/tests/test_bot/test_plugin.py
@@ -9,7 +9,7 @@ async def command_hook(ctx: crescent.Context) -> None:
     await ctx.respond("Command hook called.")
 
 
-plugin = crescent.Plugin("plugin", [plugin_hook])
+plugin = crescent.Plugin("plugin", command_hooks=[plugin_hook])
 
 
 @plugin.include

--- a/tests/test_bot/test_plugin.py
+++ b/tests/test_bot/test_plugin.py
@@ -9,7 +9,7 @@ async def command_hook(ctx: crescent.Context) -> None:
     await ctx.respond("Command hook called.")
 
 
-plugin = crescent.Plugin("plugin", command_hooks=[plugin_hook])
+plugin = crescent.Plugin(command_hooks=[plugin_hook])
 
 
 @plugin.include

--- a/tests/test_bot/test_plugin.py
+++ b/tests/test_bot/test_plugin.py
@@ -17,3 +17,13 @@ plugin = crescent.Plugin("plugin", [plugin_hook])
 @crescent.command
 async def plugin_cmd(ctx: crescent.Context) -> None:
     await ctx.respond("plugins work")
+
+
+@plugin.load_hook
+def on_load() -> None:
+    print("Plugin loaded")
+
+
+@plugin.unload_hook
+def on_unload() -> None:
+    print("Plugin unloaded")


### PR DESCRIPTION
Introduces a breaking change `crescent.catch_command` and other catch decorators can no longer be stacked. Not a huge issue imo since this shouldn't have been done anyway.