### PR TITLE
:bug: Autocomplete now works properly when roles are an option in the command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ async def on_message_create(event: hikari.MessageCreateEvent):
 Using crescent's event decorator lets you use
 crescent's [event error handling system](https://github.com/magpie-dev/hikari-crescent/blob/main/examples/error_handling/basic.py#L27).
 
+# Extensions
+Crescent has 2 builtin extensions.
+
+- [crescent-ext-cooldowns](https://github.com/magpie-dev/hikari-crescent/tree/main/examples/ext/cooldowns) - Allows you to add sliding window rate limits to your commands.
+- [crescent-ext-tasks](https://github.com/magpie-dev/hikari-crescent/tree/main/examples/ext/tasks) - Schedules functions to loop in the background at specified intervals.
+
+
 # Support
 Contact `Lunarmagpie❤#0001` on Discord or create an issue. All questions are welcome!
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ crescent's [event error handling system](https://github.com/magpie-dev/hikari-cr
 Crescent has 2 builtin extensions.
 
 - [crescent-ext-cooldowns](https://github.com/magpie-dev/hikari-crescent/tree/main/examples/ext/cooldowns) - Allows you to add sliding window rate limits to your commands.
-- [crescent-ext-tasks](https://github.com/magpie-dev/hikari-crescent/tree/main/examples/ext/tasks) - Schedules functions to loop in the background at specified intervals.
+- [crescent-ext-tasks](https://github.com/magpie-dev/hikari-crescent/tree/main/examples/ext/tasks) - Schedules background tasks using loops or cronjobs.
 
 
 # Support

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -219,10 +219,11 @@ def _extract_value(option: CommandInteractionOption, interaction: CommandInterac
 
     resolved = getattr(interaction.resolved, resolved_type, None)
 
-    # `option.value` is guaranteed to have a value because `option.type` is `None`.
+    # `option.value` is guaranteed to have a value because `option.options` is `None` because
+    # this is not a command group.
     assert option.value is not None
 
-    # `resolved`` is None when an autocomplete command has a user or role as a previous option.
+    # `resolved` is None when an autocomplete command has a user or role as a previous option.
     # This should be refactored out in the autocomplete rewrite for 1.0.0
     if resolved is None:
         return Snowflake(option.value)

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -219,8 +219,7 @@ def _extract_value(option: CommandInteractionOption, interaction: CommandInterac
 
     resolved = getattr(interaction.resolved, resolved_type, None)
 
-    # `option.value` is guaranteed to have a value because `option.options` is `None` because
-    # this is not a command group.
+    # `option.value` is guaranteed to have a value because this is not a command group.
     assert option.value is not None
 
     # `resolved` is None when an autocomplete command has a user or role as a previous option.

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -11,6 +11,7 @@ from hikari import (
     CommandType,
     InteractionType,
     OptionType,
+    Snowflake,
 )
 
 from crescent.context import Context
@@ -26,7 +27,6 @@ if TYPE_CHECKING:
         CommandInteractionOption,
         InteractionCreateEvent,
         Message,
-        Snowflake,
         User,
     )
 
@@ -217,7 +217,11 @@ def _extract_value(option: CommandInteractionOption, interaction: CommandInterac
     if resolved_type is None:
         return option.value
 
-    resolved = getattr(interaction.resolved, resolved_type)
+    resolved = getattr(interaction.resolved, resolved_type, None)
+    # `resolved`` is None when an autocomplete command has a user or role as a previous option.
+    # This should be refactored out in the autocomplete rewrite for 1.0.0
+    if resolved is None:
+        return Snowflake(option.value)
     return resolved[option.value]
 
 

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -218,6 +218,10 @@ def _extract_value(option: CommandInteractionOption, interaction: CommandInterac
         return option.value
 
     resolved = getattr(interaction.resolved, resolved_type, None)
+
+    # `option.value` is guaranteed to have a value because `option.type` is `None`.
+    assert option.value is not None
+
     # `resolved`` is None when an autocomplete command has a user or role as a previous option.
     # This should be refactored out in the autocomplete rewrite for 1.0.0
     if resolved is None:

--- a/tests/crescent/internal/test_extract_value.py
+++ b/tests/crescent/internal/test_extract_value.py
@@ -35,7 +35,7 @@ def test_extract_user():
     )
     option = MockOption(type=OptionType.USER, value="12345")
 
-    assert _extract_value(option, command_interaction) == USER
+    assert _extract_value(option, command_interaction) is USER
 
 
 def test_extract_autocomplete_option():

--- a/tests/crescent/internal/test_extract_value.py
+++ b/tests/crescent/internal/test_extract_value.py
@@ -20,7 +20,26 @@ class MockOption:
 
 def test_extract_str():
     command_interaction = MockInteraction(None)
+    option = MockOption(type=OptionType.STRING, value="12345")
 
+    assert _extract_value(option, command_interaction) == "12345"
+
+
+def test_extract_user():
+    USER = object()
+
+    command_interaction = MockInteraction(
+        resolved=ResolvedOptionData(
+            users={"12345": USER}, members={}, roles={}, channels={}, messages={}, attachments={}
+        )
+    )
+    option = MockOption(type=OptionType.USER, value="12345")
+
+    assert _extract_value(option, command_interaction) == USER
+
+
+def test_extract_autocomplete_option():
+    command_interaction = MockInteraction(None)
     option = MockOption(type=OptionType.USER, value=Snowflake(12345))
 
     assert _extract_value(option, command_interaction) == Snowflake(12345)

--- a/tests/crescent/internal/test_extract_value.py
+++ b/tests/crescent/internal/test_extract_value.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from crescent.internal.handle_resp import _extract_value
+from hikari import OptionType, ResolvedOptionData, Snowflake
+import attrs
+
+
+@attrs.define
+class MockInteraction:
+    resolved: Optional[ResolvedOptionData]
+
+
+@attrs.define
+class MockOption:
+    type: OptionType | str
+    value: Snowflake | str | int | bool
+
+
+def test_extract_str():
+    command_interaction = MockInteraction(None)
+
+    option = MockOption(type=OptionType.USER, value=Snowflake(12345))
+
+    assert _extract_value(option, command_interaction) == Snowflake(12345)


### PR DESCRIPTION
Fix bug where autocomplete did not work properly when a role was the in the same command as an option with autocomplete.
For example, this now works.
```py
# There would always be an error before this function was run previously.
async def autocomplete(ctx: crescent.Context, option: hikari.AutocompleteInteractionOption):
    return [hikari.CommandChoice(name="1234", value="1234")]


@bot.include
@crescent.command
class autocomplete_test:
    role = crescent.option(hikari.Role)
    say = crescent.option(str, autocomplete=autocomplete)

    async def callback(self, ctx: crescent.Context):
        pass
```

Now a `Snowflake` object is passed instead of the user.