### PR TITLE
:sparkles: Add checking for User and Member type

### DIFF
--- a/crescent/commands/decorators.py
+++ b/crescent/commands/decorators.py
@@ -215,9 +215,6 @@ def user_command(
             deprecated=deprecated,
         )
 
-    for param in get_parameters(callback):
-        verify_member_type(callback.__name__, param.annotation, dm_enabled)
-
     return register_command(
         callback=_kwargs_to_args_callback(callback),
         command_type=CommandType.USER,

--- a/crescent/commands/decorators.py
+++ b/crescent/commands/decorators.py
@@ -8,7 +8,11 @@ from hikari import UNDEFINED, CommandOption, CommandType, Permissions, Snowflake
 
 from crescent.bot import Bot
 from crescent.commands.options import ClassCommandOption
-from crescent.commands.signature import gen_command_option, get_autocomplete_func
+from crescent.commands.signature import (
+    gen_command_option,
+    get_autocomplete_func,
+    verify_member_type,
+)
 from crescent.internal.registry import register_command
 from crescent.utils import get_parameters
 
@@ -144,6 +148,9 @@ def command(
     else:
         raise NotImplementedError("This function only works with classes and functions")
 
+    for option in options:
+        verify_member_type(callback.__name__, option.type, dm_enabled)
+
     return register_command(
         callback=callback_func,
         command_type=CommandType.SLASH,
@@ -207,6 +214,9 @@ def user_command(
             dm_enabled=dm_enabled,
             deprecated=deprecated,
         )
+
+    for param in get_parameters(callback):
+        verify_member_type(callback.__name__, param.annotation, dm_enabled)
 
     return register_command(
         callback=_kwargs_to_args_callback(callback),

--- a/crescent/commands/options.py
+++ b/crescent/commands/options.py
@@ -23,12 +23,14 @@ from hikari import (
     UndefinedNoneOr,
     UndefinedOr,
     User,
+    Member,
 )
 
 from crescent.mentionable import Mentionable
 
 if TYPE_CHECKING:
     from crescent.typedefs import AutocompleteCallbackT, OptionTypesT
+
 
 __all__ = (
     "OPTIONS_TYPE_MAP",
@@ -39,7 +41,12 @@ __all__ = (
     "ClassCommandOption",
 )
 
-OPTIONS_TYPE_MAP: dict[type[OptionTypesT], OptionType] = {
+
+class MemberInt(int):
+    ...
+
+
+OPTIONS_TYPE_MAP: dict[type[OptionTypesT], OptionType | MemberInt] = {
     str: OptionType.STRING,
     bool: OptionType.BOOLEAN,
     int: OptionType.INTEGER,
@@ -47,6 +54,7 @@ OPTIONS_TYPE_MAP: dict[type[OptionTypesT], OptionType] = {
     PartialChannel: OptionType.CHANNEL,
     Role: OptionType.ROLE,
     User: OptionType.USER,
+    Member: MemberInt(OptionType.USER),
     Mentionable: OptionType.MENTIONABLE,
     Attachment: OptionType.ATTACHMENT,
 }
@@ -89,7 +97,7 @@ Self = TypeVar("Self")
 @dataclass
 class ClassCommandOption(Generic[T]):
     name: str | None
-    type: OptionType
+    type: OptionType | MemberInt
     description: str
     default: UndefinedNoneOr[Any]
     choices: Sequence[CommandChoice] | None

--- a/crescent/commands/options.py
+++ b/crescent/commands/options.py
@@ -17,13 +17,13 @@ from hikari import (
     GuildTextChannel,
     GuildVoiceChannel,
     InteractionChannel,
+    Member,
     OptionType,
     PartialChannel,
     Role,
     UndefinedNoneOr,
     UndefinedOr,
     User,
-    Member,
 )
 
 from crescent.mentionable import Mentionable

--- a/crescent/commands/options.py
+++ b/crescent/commands/options.py
@@ -42,14 +42,14 @@ __all__ = (
 )
 
 
-class MemberInt(int):
+class MemberOptionType(int):
     """
     A version of `hikari.OptionType` that shows that the option type was created by
     using a `hikari.Member` object.
     """
 
 
-OPTIONS_TYPE_MAP: dict[type[OptionTypesT], OptionType | MemberInt] = {
+OPTIONS_TYPE_MAP: dict[type[OptionTypesT], OptionType | MemberOptionType] = {
     str: OptionType.STRING,
     bool: OptionType.BOOLEAN,
     int: OptionType.INTEGER,
@@ -57,7 +57,7 @@ OPTIONS_TYPE_MAP: dict[type[OptionTypesT], OptionType | MemberInt] = {
     PartialChannel: OptionType.CHANNEL,
     Role: OptionType.ROLE,
     User: OptionType.USER,
-    Member: MemberInt(OptionType.USER),
+    Member: MemberOptionType(OptionType.USER),
     Mentionable: OptionType.MENTIONABLE,
     Attachment: OptionType.ATTACHMENT,
 }
@@ -100,7 +100,7 @@ Self = TypeVar("Self")
 @dataclass
 class ClassCommandOption(Generic[T]):
     name: str | None
-    type: OptionType | MemberInt
+    type: OptionType | MemberOptionType
     description: str
     default: UndefinedNoneOr[Any]
     choices: Sequence[CommandChoice] | None

--- a/crescent/commands/options.py
+++ b/crescent/commands/options.py
@@ -48,8 +48,6 @@ class MemberInt(int):
     a `hikari.Member` object.
     """
 
-    ...
-
 
 OPTIONS_TYPE_MAP: dict[type[OptionTypesT], OptionType | MemberInt] = {
     str: OptionType.STRING,

--- a/crescent/commands/options.py
+++ b/crescent/commands/options.py
@@ -44,8 +44,8 @@ __all__ = (
 
 class MemberInt(int):
     """
-    A version of `hikari.OptionType` that shows that the option type was created with
-    a `hikari.Member` object.
+    A version of `hikari.OptionType` that shows that the option type was created by
+    using a `hikari.Member` object.
     """
 
 

--- a/crescent/commands/options.py
+++ b/crescent/commands/options.py
@@ -47,6 +47,7 @@ class MemberInt(int):
     A version of `hikari.OptionType` that shows that the option type was created with
     a `hikari.Member` object.
     """
+
     ...
 
 

--- a/crescent/commands/options.py
+++ b/crescent/commands/options.py
@@ -43,6 +43,10 @@ __all__ = (
 
 
 class MemberInt(int):
+    """
+    A version of `hikari.OptionType` that shows that the option type was created with
+    a `hikari.Member` object.
+    """
     ...
 
 

--- a/crescent/commands/signature.py
+++ b/crescent/commands/signature.py
@@ -123,6 +123,6 @@ def verify_member_type(
         _LOG.warning(f"`hikari.User` can be typed as `hikari.Member` in `{name}`")
     if is_member and dm_enabled:
         raise TypeError(
-            f"`{name}` must be typed with `hikari.User` or set `dm_enabled` to `True` in "
+            f"`{name}` must be typed with `hikari.User` or set `dm_enabled` to `False` in "
             "the command decorator."
         )

--- a/crescent/commands/signature.py
+++ b/crescent/commands/signature.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+from logging import getLogger
 from typing import TYPE_CHECKING, Iterable, Union, get_args, get_origin
 
 from hikari import CommandOption, OptionType
 
-from logging import getLogger
 from crescent.commands.args import (
     Arg,
     Autocomplete,

--- a/crescent/commands/signature.py
+++ b/crescent/commands/signature.py
@@ -15,7 +15,7 @@ from crescent.commands.args import (
     MinValue,
     Name,
 )
-from crescent.commands.options import OPTIONS_TYPE_MAP, MemberInt, get_channel_types
+from crescent.commands.options import OPTIONS_TYPE_MAP, MemberOptionType, get_channel_types
 from crescent.context import Context
 
 if TYPE_CHECKING:
@@ -115,9 +115,9 @@ def get_autocomplete_func(param: Parameter) -> AutocompleteCallbackT | None:
 
 
 def verify_member_type(
-    name: str, option_type: OptionType | MemberInt | int, dm_enabled: bool
+    name: str, option_type: OptionType | MemberOptionType | int, dm_enabled: bool
 ) -> None:
-    is_member = isinstance(option_type, MemberInt)
+    is_member = isinstance(option_type, MemberOptionType)
 
     if not (is_member or dm_enabled):
         _LOG.warning(f"`hikari.User` can be typed as `hikari.Member` in `{name}`")

--- a/crescent/commands/signature.py
+++ b/crescent/commands/signature.py
@@ -119,7 +119,7 @@ def verify_member_type(
 ) -> None:
     is_member = isinstance(option_type, MemberInt)
 
-    if not is_member and not dm_enabled:
+    if not (is_member or dm_enabled):
         _LOG.warning(f"`hikari.User` can be typed as `hikari.Member` in `{name}`")
     if is_member and dm_enabled:
         raise TypeError(

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -148,14 +148,6 @@ def _get_command(
     return None
 
 
-_VALUE_TYPE_LINK: dict[OptionType | int, str] = {
-    OptionType.ROLE: "roles",
-    OptionType.USER: "users",
-    OptionType.CHANNEL: "channels",
-    OptionType.ATTACHMENT: "attachments",
-}
-
-
 def _context_from_interaction_resp(interaction: CommandInteraction) -> Context:
     name: str = interaction.command_name
     group: str | None = None
@@ -200,6 +192,23 @@ def _context_from_interaction_resp(interaction: CommandInteraction) -> Context:
     )
 
 
+_VALUE_TYPE_LINK: dict[OptionType | int, str] = {
+    OptionType.ROLE: "roles",
+    OptionType.USER: "users",
+    OptionType.CHANNEL: "channels",
+    OptionType.ATTACHMENT: "attachments",
+}
+
+
+def _get_option_resolved_key(option_type: OptionType | int, in_guild: bool) -> str | None:
+    option_str = _VALUE_TYPE_LINK.get(option_type)
+
+    if in_guild and option_str == "users":
+        return "members"
+
+    return option_str
+
+
 def _options_to_kwargs(
     interaction: CommandInteraction, options: Sequence[CommandInteractionOption] | None
 ) -> dict[str, Any]:
@@ -213,7 +222,7 @@ def _extract_value(option: CommandInteractionOption, interaction: CommandInterac
     if option.type is OptionType.MENTIONABLE:
         return Mentionable._from_interaction(interaction)
 
-    resolved_type: str | None = _VALUE_TYPE_LINK.get(option.type)
+    resolved_type: str | None = _get_option_resolved_key(option.type, bool(interaction.guild_id))
 
     if resolved_type is None:
         return option.value

--- a/examples/basic/user_vs_member.py
+++ b/examples/basic/user_vs_member.py
@@ -1,0 +1,41 @@
+# Depending on whether a slash command or user command is used in a dms or guilds, you
+# can either receive a `hikari.User` or `hikari.Member` object for users respectively.
+# `hikari.Member` is a subclass of `hikari.User`.
+
+import crescent
+import hikari
+
+
+bot = crescent.Bot(token="...")
+
+
+# This slash command is enabled in dms so user is not guaranteed to be a `hikari.Member`
+# object.
+# Crescent will prevent you from typing this command with `hikari.Member` because that
+# violates type safety.
+@crescent.command(dm_enabled=True)  # `dm_enabled=True` is default.
+async def slash_command(ctx: crescent.Context, user: hikari.User):
+    ...
+
+
+# This slash command can only be used in guilds. That ensures that every user will be a
+# `hikari.Member` object.
+@crescent.command(dm_enabled=False)
+async def guild_only_slash_command(ctx: crescent.Context, user: hikari.Member):
+    ...
+
+
+# User commands must always be typed with `hikari.User`. This is because calling a user
+# command from a guild on a user that left that guild will result in a `hikari.User`
+# object. This makes it impossible to guarantee that a user will ever be a `hikari.Member`
+# object.
+# Crescent will not prevent you from typing a user command with `hikari.Member` but it is
+# not type safe so your type checker will complain.
+@crescent.user_command(dm_enabled=True)  # `dm_enabled=True` is default.
+async def user_command(ctx: crescent.Context, user: hikari.User):
+    ...
+
+
+@crescent.user_command(dm_enabled=False)
+async def guild_only_user_command(ctx: crescent.Context, user: hikari.User):
+    ...

--- a/examples/basic/user_vs_member.py
+++ b/examples/basic/user_vs_member.py
@@ -13,6 +13,7 @@ bot = crescent.Bot(token="...")
 # object.
 # Crescent will prevent you from typing this command with `hikari.Member` because that
 # violates type safety.
+@bot.include
 @crescent.command(dm_enabled=True)  # `dm_enabled=True` is default.
 async def slash_command(ctx: crescent.Context, user: hikari.User):
     ...
@@ -20,6 +21,7 @@ async def slash_command(ctx: crescent.Context, user: hikari.User):
 
 # This slash command can only be used in guilds. That ensures that every user will be a
 # `hikari.Member` object.
+@bot.include
 @crescent.command(dm_enabled=False)
 async def guild_only_slash_command(ctx: crescent.Context, user: hikari.Member):
     ...
@@ -31,11 +33,16 @@ async def guild_only_slash_command(ctx: crescent.Context, user: hikari.Member):
 # object.
 # Crescent will not prevent you from typing a user command with `hikari.Member` but it is
 # not type safe so your type checker will complain.
+@bot.include
 @crescent.user_command(dm_enabled=True)  # `dm_enabled=True` is default.
 async def user_command(ctx: crescent.Context, user: hikari.User):
     ...
 
 
+@bot.include
 @crescent.user_command(dm_enabled=False)
 async def guild_only_user_command(ctx: crescent.Context, user: hikari.User):
     ...
+
+
+bot.run()

--- a/tests/crescent/commands/test_member_or_user.py
+++ b/tests/crescent/commands/test_member_or_user.py
@@ -1,7 +1,9 @@
-from contextlib import suppress
-from pytest import LogCaptureFixture, raises
 import logging
+from contextlib import suppress
+
 import hikari
+from pytest import LogCaptureFixture, raises
+
 import crescent
 
 

--- a/tests/crescent/commands/test_member_or_user.py
+++ b/tests/crescent/commands/test_member_or_user.py
@@ -1,0 +1,54 @@
+from contextlib import suppress
+from pytest import LogCaptureFixture, raises
+import logging
+import hikari
+import crescent
+
+
+def test_log_warning_when_user_dm_disabled(caplog: LogCaptureFixture):
+    with caplog.at_level(logging.WARN):
+
+        @crescent.command(dm_enabled=False)
+        async def _(ctx: crescent.Context, user: hikari.User):
+            ...
+
+    assert caplog.text
+
+
+def test_no_log_when_user_dm_enabled(caplog: LogCaptureFixture):
+    with caplog.at_level(logging.WARN):
+
+        @crescent.command(dm_enabled=True)
+        async def _(ctx: crescent.Context, user: hikari.User):
+            ...
+
+    assert not caplog.text
+
+
+def test_exception_when_member_dm_enabled():
+    with raises(TypeError):
+
+        @crescent.command(dm_enabled=True)
+        async def _(ctx: crescent.Context, user: hikari.Member):
+            ...
+
+
+def test_no_log_when_member_dm_enabled(caplog: LogCaptureFixture):
+    with caplog.at_level(logging.WARN):
+        with suppress(TypeError):
+
+            @crescent.command(dm_enabled=True)
+            async def _(ctx: crescent.Context, user: hikari.Member):
+                ...
+
+    assert not caplog.text
+
+
+def test_no_log_when_member_dm_disabled(caplog: LogCaptureFixture):
+    with caplog.at_level(logging.WARN):
+
+        @crescent.command(dm_enabled=False)
+        async def _(ctx: crescent.Context, user: hikari.Member):
+            ...
+
+    assert not caplog.text

--- a/tests/crescent/commands/test_option_types.py
+++ b/tests/crescent/commands/test_option_types.py
@@ -2,6 +2,7 @@ from hikari import (
     Attachment,
     GuildTextChannel,
     GuildVoiceChannel,
+    Member,
     OptionType,
     PartialChannel,
     Role,
@@ -39,3 +40,11 @@ def test_option_types():
     assert options[7].type == OptionType.CHANNEL
     assert options[8].type == OptionType.CHANNEL
     assert options[9].type == OptionType.ATTACHMENT
+
+
+def test_member():
+    @command(name="member-type", dm_enabled=False)
+    class MemberType:
+        member = option(Member)
+
+    assert MemberType.metadata.app.options[0].type == OptionType.USER

--- a/tests/crescent/internal/test_extract_value.py
+++ b/tests/crescent/internal/test_extract_value.py
@@ -42,17 +42,11 @@ def test_extract_user():
 
 
 def test_extract_member():
-    USER = object()
     MEMBER = object()
 
     command_interaction = MockInteraction(
         resolved=ResolvedOptionData(
-            users={"12345": USER},
-            members={"12345": MEMBER},
-            roles={},
-            channels={},
-            messages={},
-            attachments={},
+            users={}, members={"12345": MEMBER}, roles={}, channels={}, messages={}, attachments={}
         ),
         guild_id=12345,
     )

--- a/tests/crescent/internal/test_extract_value.py
+++ b/tests/crescent/internal/test_extract_value.py
@@ -11,6 +11,7 @@ from crescent.internal.handle_resp import _extract_value
 @attrs.define
 class MockInteraction:
     resolved: Optional[ResolvedOptionData]
+    guild_id: int | None
 
 
 @attrs.define
@@ -20,7 +21,7 @@ class MockOption:
 
 
 def test_extract_str():
-    command_interaction = MockInteraction(None)
+    command_interaction = MockInteraction(None, None)
     option = MockOption(type=OptionType.STRING, value="12345")
 
     assert _extract_value(option, command_interaction) == "12345"
@@ -32,15 +33,36 @@ def test_extract_user():
     command_interaction = MockInteraction(
         resolved=ResolvedOptionData(
             users={"12345": USER}, members={}, roles={}, channels={}, messages={}, attachments={}
-        )
+        ),
+        guild_id=None,
     )
     option = MockOption(type=OptionType.USER, value="12345")
 
     assert _extract_value(option, command_interaction) is USER
 
 
+def test_extract_member():
+    USER = object()
+    MEMBER = object()
+
+    command_interaction = MockInteraction(
+        resolved=ResolvedOptionData(
+            users={"12345": USER},
+            members={"12345": MEMBER},
+            roles={},
+            channels={},
+            messages={},
+            attachments={},
+        ),
+        guild_id=12345,
+    )
+    option = MockOption(type=OptionType.USER, value="12345")
+
+    assert _extract_value(option, command_interaction) is MEMBER
+
+
 def test_extract_autocomplete_option():
-    command_interaction = MockInteraction(None)
+    command_interaction = MockInteraction(None, None)
     option = MockOption(type=OptionType.USER, value=Snowflake(12345))
 
     assert _extract_value(option, command_interaction) == Snowflake(12345)


### PR DESCRIPTION
If you type a `dm_enabled=True` command with `hikari.User`, nothing will happen.
If you type a `dm_enabled=True` command with `hikari.Member`, an error will be raised because this isn't type safe.
If you type a `dm_enabled=False` command with `hikari.User`, you will get a warning telling you you can use `hikari.Member`
if you type a `dm_enabled=False` command with `hikari.Member`, nothing will happen.