### PR TITLE
:fire: Remove deprecated features

### DIFF
--- a/crescent/commands/decorators.py
+++ b/crescent/commands/decorators.py
@@ -65,7 +65,6 @@ def command(
     description: str | None = ...,
     default_member_permissions: UndefinedType | int | Permissions = ...,
     dm_enabled: bool = ...,
-    deprecated: bool = ...,
 ) -> Callable[
     [CommandCallbackT | type[ClassCommandProto]], MetaStruct[CommandCallbackT, AppCommandMeta],
 ]:
@@ -81,7 +80,6 @@ def command(
     description: str | None = None,
     default_member_permissions: UndefinedType | int | Permissions = UNDEFINED,
     dm_enabled: bool = True,
-    deprecated: bool = False,
 ) -> MetaStruct[CommandCallbackT, AppCommandMeta] | Callable[
     [CommandCallbackT | type[ClassCommandProto]], MetaStruct[CommandCallbackT, AppCommandMeta],
 ]:
@@ -93,7 +91,6 @@ def command(
             description=description,
             default_member_permissions=default_member_permissions,
             dm_enabled=dm_enabled,
-            deprecated=deprecated,
         )
 
     autocomplete: dict[str, AutocompleteCallbackT] = {}
@@ -153,7 +150,6 @@ def command(
         options=options,
         default_member_permissions=default_member_permissions,
         dm_enabled=dm_enabled,
-        deprecated=deprecated,
         autocomplete=autocomplete,
     )
 
@@ -181,7 +177,6 @@ def user_command(
     name: str | None = ...,
     default_member_permissions: UndefinedType | int | Permissions = ...,
     dm_enabled: bool = ...,
-    deprecated: bool = ...,
 ) -> Callable[[UserCommandCallbackT], MetaStruct[UserCommandCallbackT, AppCommandMeta]]:
     ...
 
@@ -194,7 +189,6 @@ def user_command(
     name: str | None = None,
     default_member_permissions: UndefinedType | int | Permissions = UNDEFINED,
     dm_enabled: bool = True,
-    deprecated: bool = False,
 ) -> Callable[
     [UserCommandCallbackT], MetaStruct[UserCommandCallbackT, AppCommandMeta]
 ] | MetaStruct[UserCommandCallbackT, AppCommandMeta]:
@@ -205,7 +199,6 @@ def user_command(
             name=name,
             default_member_permissions=default_member_permissions,
             dm_enabled=dm_enabled,
-            deprecated=deprecated,
         )
 
     return register_command(
@@ -215,7 +208,6 @@ def user_command(
         guild=guild,
         default_member_permissions=default_member_permissions,
         dm_enabled=dm_enabled,
-        deprecated=deprecated,
     )
 
 
@@ -233,7 +225,6 @@ def message_command(
     name: str | None = ...,
     default_member_permissions: UndefinedType | int | Permissions = ...,
     dm_enabled: bool = ...,
-    deprecated: bool = ...,
 ) -> Callable[[MessageCommandCallbackT], MetaStruct[MessageCommandCallbackT, AppCommandMeta]]:
     ...
 
@@ -246,7 +237,6 @@ def message_command(
     name: str | None = None,
     default_member_permissions: UndefinedType | int | Permissions = UNDEFINED,
     dm_enabled: bool = True,
-    deprecated: bool = False,
 ) -> Callable[
     [MessageCommandCallbackT], MetaStruct[MessageCommandCallbackT, AppCommandMeta],
 ] | MetaStruct[MessageCommandCallbackT, AppCommandMeta]:
@@ -257,7 +247,6 @@ def message_command(
             name=name,
             default_member_permissions=default_member_permissions,
             dm_enabled=dm_enabled,
-            deprecated=deprecated,
         )
 
     return register_command(
@@ -267,5 +256,4 @@ def message_command(
         guild=guild,
         default_member_permissions=default_member_permissions,
         dm_enabled=dm_enabled,
-        deprecated=deprecated,
     )

--- a/crescent/internal/app_command.py
+++ b/crescent/internal/app_command.py
@@ -167,7 +167,6 @@ class AppCommandMeta:
     autocomplete: dict[str, AutocompleteCallbackT] = field(factory=dict)
     group: Group | None = None
     sub_group: SubGroup | None = None
-    deprecated: bool = False
     hooks: list[HookCallbackT] = field(factory=list)
     after_hooks: list[HookCallbackT] = field(factory=list)
 

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -54,7 +54,6 @@ def register_command(
     options: Sequence[CommandOption] | None = None,
     default_member_permissions: UndefinedType | int | Permissions = UNDEFINED,
     dm_enabled: bool = True,
-    deprecated: bool = False,
     autocomplete: dict[str, AutocompleteCallbackT] = {},
 ) -> MetaStruct[T, AppCommandMeta]:
 
@@ -66,7 +65,6 @@ def register_command(
         app_set_hooks=[_command_app_set_hook],
         plugin_unload_hooks=[_plugin_unload_callback],
         metadata=AppCommandMeta(
-            deprecated=deprecated,
             autocomplete=autocomplete,
             app=AppCommand(
                 type=command_type,
@@ -147,10 +145,7 @@ class CommandHandler:
         built_commands: dict[Unique, AppCommand] = {}
 
         for command in self.registry.values():
-            if command.metadata.deprecated:
-                continue
-
-            elif command.metadata.sub_group:
+            if command.metadata.sub_group:
                 # If a command has a sub_group, it must be nested 2 levels deep.
                 #
                 # command

--- a/crescent/plugin.py
+++ b/crescent/plugin.py
@@ -30,11 +30,6 @@ class PluginManager:
         self.plugins: dict[str, Plugin] = {}
         self._bot = bot
 
-    def add_plugin(self, plugin: Plugin, force: bool = False) -> None:
-        _LOG.warning("`add_plugin` is deprecated and will be removed in a future release.")
-
-        self._add_plugin("", plugin, refresh=force)
-
     def unload(self, path: str) -> None:
         plugin = self.plugins.pop(path)
         plugin._unload()
@@ -145,16 +140,10 @@ class PluginManager:
 class Plugin:
     def __init__(
         self,
-        name: str | None = None,
         *,
         command_hooks: list[HookCallbackT] | None = None,
         command_after_hooks: list[HookCallbackT] | None = None,
     ) -> None:
-        if name is not None:
-            _LOG.warning(
-                "Plugin option `name` is deprecated and will be removed in a future release."
-            )
-
         self.command_hooks = command_hooks
         self.command_after_hooks = command_after_hooks
         self._app: Bot | None = None

--- a/examples/hooks/plugin_hooks.py
+++ b/examples/hooks/plugin_hooks.py
@@ -13,7 +13,6 @@ async def second_hook(ctx: crescent.Context) -> None:
 
 
 plugin = crescent.Plugin(
-    "example",
     command_hooks=[first_hook],  # Hooks to execute before the command
     command_after_hooks=[first_hook],  # Hooks to execute after the command
 )

--- a/tests/crescent/hooks/test_hook_order.py
+++ b/tests/crescent/hooks/test_hook_order.py
@@ -32,7 +32,7 @@ else:
 
 def test_hook_order():
     bot = Bot("NO TOKEN", command_hooks=[MockHook("bot")])
-    plugin = Plugin("PLUGIN", command_hooks=[MockHook("plugin")])
+    plugin = Plugin(command_hooks=[MockHook("plugin")])
     group = Group("BOT_GROUP", hooks=[MockHook("group")])
     subgroup = group.sub_group("SUBGROUP", hooks=[MockHook("subgroup")])
 
@@ -76,7 +76,7 @@ def test_hook_order():
     async def c6(ctx) -> None:
         ...
 
-    bot.plugins.add_plugin(plugin)
+    bot.plugins._add_plugin("", plugin)
 
     assert c1.metadata.hooks == ["command", "bot"]
     assert c2.metadata.hooks == ["command", "group", "bot"]
@@ -88,7 +88,7 @@ def test_hook_order():
 
 def test_after_hook_order():
     bot = Bot("NO TOKEN", command_after_hooks=[MockHook("bot")])
-    plugin = Plugin("PLUGIN", command_after_hooks=[MockHook("plugin")])
+    plugin = Plugin(command_after_hooks=[MockHook("plugin")])
     group = Group("BOT_GROUP", after_hooks=[MockHook("group")])
     subgroup = group.sub_group("SUBGROUP", after_hooks=[MockHook("subgroup")])
 
@@ -132,7 +132,7 @@ def test_after_hook_order():
     async def c6(ctx) -> None:
         ...
 
-    bot.plugins.add_plugin(plugin)
+    bot.plugins._add_plugin("", plugin)
 
     assert c1.metadata.after_hooks == ["command", "bot"]
     assert c2.metadata.after_hooks == ["command", "group", "bot"]

--- a/tests/crescent/internal/test_registry.py
+++ b/tests/crescent/internal/test_registry.py
@@ -57,50 +57,6 @@ class TestRegistry:
         ]
 
     @mark.asyncio
-    async def test_post_deprecated_commands(self):
-        bot = MockBot(default_guild=GUILD_ID)
-
-        @bot.include
-        @command(deprecated=True)
-        async def slash_command_deprecated(ctx: Context):
-            pass
-
-        @bot.include
-        @_user_command(deprecated=True)
-        async def user_command_deprecated(ctx: Context, user: User):
-            pass
-
-        @bot.include
-        @_message_command(deprecated=True)
-        async def message_command_deprecated(ctx: Context, message: Message):
-            pass
-
-        @bot.include
-        @command
-        async def slash_command(ctx: Context):
-            pass
-
-        @bot.include
-        @_user_command
-        async def user_command(ctx: Context, user: User):
-            pass
-
-        @bot.include
-        @_message_command
-        async def message_command(ctx: Context, message: Message):
-            pass
-
-        bot.run()
-        await bot.wait_until_ready()
-        print(self.posted_commands[GUILD_ID])
-
-        assert self.posted_commands[GUILD_ID] == [
-            slash_command.metadata.app,
-            user_command.metadata.app,
-            message_command.metadata.app,
-        ]
-
-    @mark.asyncio
     async def test_dont_register_commands(self):
         stack = ExitStack()
         register_commands = stack.enter_context(patch.object(CommandHandler, "register_commands"))

--- a/tests/test_bot/test_bot.py
+++ b/tests/test_bot/test_bot.py
@@ -183,7 +183,6 @@ async def error_autocomplete_command(
     await ctx.respond(option)
 
 
-
 async def autocomplete_response(
     ctx: crescent.Context, option: hikari.AutocompleteInteractionOption
 ) -> Sequence[hikari.CommandChoice]:


### PR DESCRIPTION
Removes plugin names, add_plugin, and the command deprecated kwarg.
Next release will be `0.3.0` so this is a good time to do this.