### PR TITLE
Rename `AppCommandMeta.app` property to `app_command`

### DIFF
--- a/crescent/internal/app_command.py
+++ b/crescent/internal/app_command.py
@@ -50,9 +50,9 @@ class Unique:
     @classmethod
     def from_meta_struct(cls: Type[Unique], command: Includable[AppCommandMeta]) -> Unique:
         return cls(
-            name=command.metadata.app.name,
-            type=command.metadata.app.type,
-            guild_id=command.metadata.app.guild_id,
+            name=command.metadata.app_command.name,
+            type=command.metadata.app_command.type,
+            guild_id=command.metadata.app_command.guild_id,
             group=command.metadata.group.name if command.metadata.group else None,
             sub_group=command.metadata.sub_group.name if command.metadata.sub_group else None,
         )
@@ -60,9 +60,9 @@ class Unique:
     @classmethod
     def from_app_command_meta(cls: Type[Unique], command: AppCommandMeta) -> Unique:
         return cls(
-            name=command.app.name,
-            type=command.app.type,
-            guild_id=command.app.guild_id,
+            name=command.app_command.name,
+            type=command.app_command.type,
+            guild_id=command.app_command.guild_id,
             group=command.group.name if command.group else None,
             sub_group=command.sub_group.name if command.sub_group else None,
         )
@@ -161,7 +161,7 @@ class AppCommand(CommandBuilder):
 
 @define
 class AppCommandMeta:
-    app: AppCommand
+    app_command: AppCommand
     callback: CommandCallbackT
     autocomplete: dict[str, AutocompleteCallbackT] = field(factory=dict)
     group: Group | None = None
@@ -173,9 +173,9 @@ class AppCommandMeta:
     @property
     def unique(self) -> Unique:
         return Unique(
-            self.app.name,
-            self.app.type,
-            self.app.guild_id,
+            self.app_command.name,
+            self.app_command.type,
+            self.app_command.guild_id,
             self.group.name if self.group else None,
             self.sub_group.name if self.sub_group else None,
         )

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -128,7 +128,9 @@ class CommandHandler:
         self.registry: dict[Unique, Includable[AppCommandMeta]] = {}
 
     def register(self, command: Includable[AppCommandMeta]) -> Includable[AppCommandMeta]:
-        command.metadata.app_command.guild_id = command.metadata.app_command.guild_id or self.bot.default_guild
+        command.metadata.app_command.guild_id = (
+            command.metadata.app_command.guild_id or self.bot.default_guild
+        )
         self.registry[command.metadata.unique] = command
         return command
 

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -66,7 +66,7 @@ def register_command(
             callback=callback,
             deprecated=deprecated,
             autocomplete=autocomplete,
-            app=AppCommand(
+            app_command=AppCommand(
                 type=command_type,
                 description=description,
                 guild_id=guild,
@@ -128,7 +128,7 @@ class CommandHandler:
         self.registry: dict[Unique, Includable[AppCommandMeta]] = {}
 
     def register(self, command: Includable[AppCommandMeta]) -> Includable[AppCommandMeta]:
-        command.metadata.app.guild_id = command.metadata.app.guild_id or self.bot.default_guild
+        command.metadata.app_command.guild_id = command.metadata.app_command.guild_id or self.bot.default_guild
         self.registry[command.metadata.unique] = command
         return command
 
@@ -161,8 +161,8 @@ class CommandHandler:
                 # hold the subcommand.
                 key = Unique(
                     name=unwrap(command.metadata.group).name,
-                    type=command.metadata.app.type,
-                    guild_id=command.metadata.app.guild_id,
+                    type=command.metadata.app_command.type,
+                    guild_id=command.metadata.app_command.guild_id,
                     group=None,
                     sub_group=None,
                 )
@@ -171,11 +171,11 @@ class CommandHandler:
                     built_commands[key] = AppCommand(
                         name=unwrap(command.metadata.group).name,
                         description=unwrap(command.metadata.group).description or "No Description",
-                        type=command.metadata.app.type,
-                        guild_id=command.metadata.app.guild_id,
+                        type=command.metadata.app_command.type,
+                        guild_id=command.metadata.app_command.guild_id,
                         options=[],
-                        default_member_permissions=command.metadata.app.default_member_permissions,
-                        is_dm_enabled=command.metadata.app.is_dm_enabled,
+                        default_member_permissions=command.metadata.app_command.default_member_permissions,
+                        is_dm_enabled=command.metadata.app_command.is_dm_enabled,
                     )
 
                 # The top-level command now exists. A subcommand group now if placed
@@ -206,10 +206,10 @@ class CommandHandler:
 
                 cast("list[CommandOption]", sub_command_group.options).append(
                     CommandOption(
-                        name=command.metadata.app.name,
-                        description=unwrap(command.metadata.app.description),
+                        name=command.metadata.app_command.name,
+                        description=unwrap(command.metadata.app_command.description),
                         type=OptionType.SUB_COMMAND,
-                        options=command.metadata.app.options,
+                        options=command.metadata.app_command.options,
                         is_required=False,
                     )
                 )
@@ -227,8 +227,8 @@ class CommandHandler:
                 # hold the subcommand.
                 key = Unique(
                     name=command.metadata.group.name,
-                    type=command.metadata.app.type,
-                    guild_id=command.metadata.app.guild_id,
+                    type=command.metadata.app_command.type,
+                    guild_id=command.metadata.app_command.guild_id,
                     group=None,
                     sub_group=None,
                 )
@@ -237,27 +237,27 @@ class CommandHandler:
                     built_commands[key] = AppCommand(
                         name=command.metadata.group.name,
                         description=unwrap(command.metadata.group).description or "No Description",
-                        type=command.metadata.app.type,
-                        guild_id=command.metadata.app.guild_id,
+                        type=command.metadata.app_command.type,
+                        guild_id=command.metadata.app_command.guild_id,
                         options=[],
-                        default_member_permissions=command.metadata.app.default_member_permissions,
-                        is_dm_enabled=command.metadata.app.is_dm_enabled,
+                        default_member_permissions=command.metadata.app_command.default_member_permissions,
+                        is_dm_enabled=command.metadata.app_command.is_dm_enabled,
                     )
 
                 # No checking has to be done before appending `command` since it is the
                 # lowest level.
                 cast("list[CommandOption]", built_commands[key].options).append(
                     CommandOption(
-                        name=command.metadata.app.name,
-                        description=unwrap(command.metadata.app.description),
-                        type=command.metadata.app.type,
-                        options=command.metadata.app.options,
+                        name=command.metadata.app_command.name,
+                        description=unwrap(command.metadata.app_command.description),
+                        type=command.metadata.app_command.type,
+                        options=command.metadata.app_command.options,
                         is_required=False,
                     )
                 )
 
             else:
-                built_commands[Unique.from_meta_struct(command)] = command.metadata.app
+                built_commands[Unique.from_meta_struct(command)] = command.metadata.app_command
 
         return tuple(built_commands.values())
 

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -176,7 +176,9 @@ class CommandHandler:
                         type=command.metadata.app_command.type,
                         guild_id=command.metadata.app_command.guild_id,
                         options=[],
-                        default_member_permissions=command.metadata.app_command.default_member_permissions,  # noqa
+                        default_member_permissions=(
+                            command.metadata.app_command.default_member_permissions
+                        ),
                         is_dm_enabled=command.metadata.app_command.is_dm_enabled,
                     )
 
@@ -242,7 +244,9 @@ class CommandHandler:
                         type=command.metadata.app_command.type,
                         guild_id=command.metadata.app_command.guild_id,
                         options=[],
-                        default_member_permissions=command.metadata.app_command.default_member_permissions,  # noqa
+                        default_member_permissions=(
+                            command.metadata.app_command.default_member_permissions
+                        ),
                         is_dm_enabled=command.metadata.app_command.is_dm_enabled,
                     )
 

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -176,7 +176,7 @@ class CommandHandler:
                         type=command.metadata.app_command.type,
                         guild_id=command.metadata.app_command.guild_id,
                         options=[],
-                        default_member_permissions=command.metadata.app_command.default_member_permissions,
+                        default_member_permissions=command.metadata.app_command.default_member_permissions,  # noqa
                         is_dm_enabled=command.metadata.app_command.is_dm_enabled,
                     )
 
@@ -242,7 +242,7 @@ class CommandHandler:
                         type=command.metadata.app_command.type,
                         guild_id=command.metadata.app_command.guild_id,
                         options=[],
-                        default_member_permissions=command.metadata.app_command.default_member_permissions,
+                        default_member_permissions=command.metadata.app_command.default_member_permissions,  # noqa
                         is_dm_enabled=command.metadata.app_command.is_dm_enabled,
                     )
 

--- a/tests/crescent/commands/test_command_function.py
+++ b/tests/crescent/commands/test_command_function.py
@@ -25,7 +25,7 @@ class TestCommandFunction:
 
         assert callback.metadata == AppCommandMeta(
             callback=callback.metadata.callback,
-            app=AppCommand(
+            app_command=AppCommand(
                 type=CommandType.SLASH,
                 name="test",
                 guild_id=12345678,
@@ -47,7 +47,7 @@ class TestCommandFunction:
 
         assert callback.metadata == AppCommandMeta(
             callback=callback.metadata.callback,
-            app=AppCommand(
+            app_command=AppCommand(
                 type=CommandType.SLASH,
                 name="callback",
                 guild_id=None,
@@ -83,11 +83,11 @@ class TestCommandFunction:
         ):
             pass
 
-        print(callback.metadata.app.options[2].channel_types)
+        print(callback.metadata.app_command.options[2].channel_types)
 
         assert callback.metadata == AppCommandMeta(
             callback=callback.metadata.callback,
-            app=AppCommand(
+            app_command=AppCommand(
                 type=CommandType.SLASH,
                 name="callback",
                 default_member_permissions=UNDEFINED,
@@ -127,7 +127,7 @@ class TestCommandFunction:
 
         assert callback.metadata == AppCommandMeta(
             callback=callback.metadata.callback,
-            app=AppCommand(
+            app_command=AppCommand(
                 type=CommandType.MESSAGE,
                 name="callback",
                 default_member_permissions=UNDEFINED,
@@ -143,7 +143,7 @@ class TestCommandFunction:
 
         assert callback.metadata == AppCommandMeta(
             callback=callback.metadata.callback,
-            app=AppCommand(
+            app_command=AppCommand(
                 type=CommandType.USER,
                 name="callback",
                 default_member_permissions=UNDEFINED,

--- a/tests/crescent/commands/test_defaults.py
+++ b/tests/crescent/commands/test_defaults.py
@@ -8,11 +8,11 @@ def test_defaults():
     async def test_command(ctx: Context):
         ...
 
-    assert test_command.metadata.app.name == "test_command"
-    assert test_command.metadata.app.guild_id is None
-    assert test_command.metadata.app.description == "No Description"
-    assert test_command.metadata.app.default_member_permissions is UNDEFINED
-    assert test_command.metadata.app.is_dm_enabled
+    assert test_command.metadata.app_command.name == "test_command"
+    assert test_command.metadata.app_command.guild_id is None
+    assert test_command.metadata.app_command.description == "No Description"
+    assert test_command.metadata.app_command.default_member_permissions is UNDEFINED
+    assert test_command.metadata.app_command.is_dm_enabled
 
 
 def test_user_command_defaults():
@@ -20,10 +20,10 @@ def test_user_command_defaults():
     async def test_command(ctx: Context, user: User):
         ...
 
-    assert test_command.metadata.app.name == "test_command"
-    assert test_command.metadata.app.guild_id is None
-    assert test_command.metadata.app.default_member_permissions is UNDEFINED
-    assert test_command.metadata.app.is_dm_enabled
+    assert test_command.metadata.app_command.name == "test_command"
+    assert test_command.metadata.app_command.guild_id is None
+    assert test_command.metadata.app_command.default_member_permissions is UNDEFINED
+    assert test_command.metadata.app_command.is_dm_enabled
 
 
 def test_message_command_defaults():
@@ -31,10 +31,10 @@ def test_message_command_defaults():
     async def test_command(ctx: Context, user: Message):
         ...
 
-    assert test_command.metadata.app.name == "test_command"
-    assert test_command.metadata.app.guild_id is None
-    assert test_command.metadata.app.default_member_permissions is UNDEFINED
-    assert test_command.metadata.app.is_dm_enabled
+    assert test_command.metadata.app_command.name == "test_command"
+    assert test_command.metadata.app_command.guild_id is None
+    assert test_command.metadata.app_command.default_member_permissions is UNDEFINED
+    assert test_command.metadata.app_command.is_dm_enabled
 
 
 def test_not_default():
@@ -48,11 +48,11 @@ def test_not_default():
     async def test_command(ctx: Context):
         ...
 
-    assert test_command.metadata.app.name == "test_name"
-    assert test_command.metadata.app.guild_id == 123456
-    assert test_command.metadata.app.description == "test description"
-    assert test_command.metadata.app.default_member_permissions is Permissions.BAN_MEMBERS
-    assert not test_command.metadata.app.is_dm_enabled
+    assert test_command.metadata.app_command.name == "test_name"
+    assert test_command.metadata.app_command.guild_id == 123456
+    assert test_command.metadata.app_command.description == "test description"
+    assert test_command.metadata.app_command.default_member_permissions is Permissions.BAN_MEMBERS
+    assert not test_command.metadata.app_command.is_dm_enabled
 
 
 def test_message_command_not_default():
@@ -65,10 +65,10 @@ def test_message_command_not_default():
     async def test_command(ctx: Context):
         ...
 
-    assert test_command.metadata.app.name == "Test Name"
-    assert test_command.metadata.app.guild_id == 123456
-    assert test_command.metadata.app.default_member_permissions is Permissions.BAN_MEMBERS
-    assert not test_command.metadata.app.is_dm_enabled
+    assert test_command.metadata.app_command.name == "Test Name"
+    assert test_command.metadata.app_command.guild_id == 123456
+    assert test_command.metadata.app_command.default_member_permissions is Permissions.BAN_MEMBERS
+    assert not test_command.metadata.app_command.is_dm_enabled
 
 
 def test_user_command_not_default():
@@ -81,7 +81,7 @@ def test_user_command_not_default():
     async def test_command(ctx: Context):
         ...
 
-    assert test_command.metadata.app.name == "Test Name"
-    assert test_command.metadata.app.guild_id == 123456
-    assert test_command.metadata.app.default_member_permissions is Permissions.BAN_MEMBERS
-    assert not test_command.metadata.app.is_dm_enabled
+    assert test_command.metadata.app_command.name == "Test Name"
+    assert test_command.metadata.app_command.guild_id == 123456
+    assert test_command.metadata.app_command.default_member_permissions is Permissions.BAN_MEMBERS
+    assert not test_command.metadata.app_command.is_dm_enabled

--- a/tests/crescent/commands/test_option_types.py
+++ b/tests/crescent/commands/test_option_types.py
@@ -25,7 +25,7 @@ def test_option_types():
         channel_list = option([GuildTextChannel, GuildVoiceChannel])
         attachment = option(Attachment)
 
-    options = AllOptionTypes.metadata.app.options
+    options = AllOptionTypes.metadata.app_command.options
 
     assert options
 

--- a/tests/crescent/internal/test_registry.py
+++ b/tests/crescent/internal/test_registry.py
@@ -51,9 +51,9 @@ class TestRegistry:
         await bot.wait_until_ready()
 
         assert self.posted_commands[GUILD_ID] == [
-            slash_command.metadata.app,
-            user_command.metadata.app,
-            message_command.metadata.app,
+            slash_command.metadata.app_command,
+            user_command.metadata.app_command,
+            message_command.metadata.app_command,
         ]
 
     @mark.asyncio
@@ -95,9 +95,9 @@ class TestRegistry:
         print(self.posted_commands[GUILD_ID])
 
         assert self.posted_commands[GUILD_ID] == [
-            slash_command.metadata.app,
-            user_command.metadata.app,
-            message_command.metadata.app,
+            slash_command.metadata.app_command,
+            user_command.metadata.app_command,
+            message_command.metadata.app_command,
         ]
 
     @mark.asyncio


### PR DESCRIPTION
I hope I didn't miss anything...

@Lunarmagpie also I don't know how the prefix command naming works, is having it app_command acceptable here?