### PR TITLE
:sparkles: Add autocomplete context

### DIFF
--- a/crescent/__init__.py
+++ b/crescent/__init__.py
@@ -31,6 +31,7 @@ __all__: Sequence[str] = (
     "SubGroup",
     "Bot",
     "Context",
+    "AutocompleteContext",
     "catch_command",
     "catch_event",
     "catch_autocomplete",

--- a/crescent/bot.py
+++ b/crescent/bot.py
@@ -29,7 +29,7 @@ from crescent.utils import add_hooks
 if TYPE_CHECKING:
     from typing import Any, Callable, Sequence, TypeVar
 
-    from crescent.context import Context
+    from crescent.context import Context, AutocompleteContext
     from crescent.typedefs import (
         AutocompleteErrorHandlerCallbackT,
         CommandErrorHandlerCallbackT,
@@ -220,7 +220,7 @@ class Bot(GatewayBot):
     async def on_crescent_autocomplete_error(
         self,
         exc: Exception,
-        ctx: Context,
+        ctx: AutocompleteContext,
         option: AutocompleteInteractionOption,
         was_handled: bool,
     ) -> None:

--- a/crescent/context.py
+++ b/crescent/context.py
@@ -47,7 +47,7 @@ class BaseContext:
     interaction: CommandInteraction
     """The interaction object."""
     app: Bot
-    """The client application."""
+    """The application instance."""
     application_id: Snowflake
     """The ID for the client that this interaction belongs to."""
     type: int
@@ -69,7 +69,7 @@ class BaseContext:
     """The member object for the user that triggered this interaction, if used in a guild."""
 
     command: str
-    """The name of the command that was used."""
+    """The name of the command."""
     command_type: hikari.CommandType
     group: str | None
     sub_group: str | None

--- a/crescent/context.py
+++ b/crescent/context.py
@@ -10,6 +10,7 @@ from hikari import (
     GuildChannel,
     Member,
     MessageFlag,
+    PartialInteraction,
     ResponseType,
     Snowflake,
     User,
@@ -42,9 +43,9 @@ __all__: Sequence[str] = ("Context", "AutocompleteContext")
 
 @define
 class BaseContext:
-    """Represents the context for command interactions"""
+    """Represents the context for interactions"""
 
-    interaction: CommandInteraction
+    interaction: PartialInteraction
     """The interaction object."""
     app: Bot
     """The application instance."""
@@ -80,6 +81,8 @@ class BaseContext:
 @define
 class Context(BaseContext):
     """Represents the context for command interactions"""
+
+    interaction: CommandInteraction
 
     _has_replied: bool = False
     _used_first_resp: bool = False
@@ -281,3 +284,5 @@ class Context(BaseContext):
 
 class AutocompleteContext(BaseContext):
     """Represents the context for autocomplete interactions"""
+
+    interaction: CommandInteraction

--- a/crescent/context.py
+++ b/crescent/context.py
@@ -19,7 +19,7 @@ from hikari import (
 from crescent.utils import map_or
 
 if TYPE_CHECKING:
-    from typing import Any, Literal, Sequence
+    from typing import Any, Literal, Sequence, TypeVar, Type
 
     from hikari import (
         CommandInteraction,
@@ -36,6 +36,8 @@ if TYPE_CHECKING:
     from hikari.api import ComponentBuilder
 
     from crescent.bot import Bot
+
+    ContextT = TypeVar("ContextT", bound="BaseContext")
 
 
 __all__: Sequence[str] = ("Context", "AutocompleteContext")
@@ -76,6 +78,27 @@ class BaseContext:
     sub_group: str | None
     options: dict[str, Any]
     """The options that were provided by the user."""
+
+    # Mypy is too dumb for lowercase type to work here
+    def _into_subclass(self, ctx_type: Type[ContextT]) -> ContextT:
+        return ctx_type(
+            interaction=self.interaction,
+            app=self.app,
+            application_id=self.application_id,
+            type=self.type,
+            token=self.token,
+            id=self.id,
+            version=self.version,
+            channel_id=self.channel_id,
+            guild_id=self.guild_id,
+            user=self.user,
+            member=self.member,
+            command=self.command,
+            group=self.group,
+            sub_group=self.sub_group,
+            command_type=self.command_type,
+            options=self.options,
+        )
 
 
 @define

--- a/crescent/context.py
+++ b/crescent/context.py
@@ -19,7 +19,7 @@ from hikari import (
 from crescent.utils import map_or
 
 if TYPE_CHECKING:
-    from typing import Any, Literal, Sequence, TypeVar, Type
+    from typing import Any, Literal, Sequence, Type, TypeVar
 
     from hikari import (
         CommandInteraction,

--- a/crescent/context.py
+++ b/crescent/context.py
@@ -37,31 +37,51 @@ if TYPE_CHECKING:
     from crescent.bot import Bot
 
 
-__all__: Sequence[str] = ("Context",)
+__all__: Sequence[str] = ("Context", "AutocompleteContext")
 
 
 @define
-class Context:
-    """Represents the context for interactions"""
+class BaseContext:
+    """Represents the context for command interactions"""
 
     interaction: CommandInteraction
+    """The interaction object."""
     app: Bot
+    """The client application."""
     application_id: Snowflake
+    """The ID for the client that this interaction belongs to."""
     type: int
+    """The type of the interaction."""
     token: str
+    """The token for the interaction."""
     id: Snowflake
+    """The ID of the interaction."""
     version: int
+    """Version of the interaction system this interaction is under."""
 
     channel_id: Snowflake
+    """The channel ID of the channel that the interaction was used in."""
     guild_id: Snowflake | None
+    """The guild ID of the guild that this interaction was used in."""
     user: User
+    """The user who triggered this command interaction."""
     member: Member | None
+    """The member object for the user that triggered this interaction, if used in a guild."""
 
     command: str
+    """The name of the command that was used."""
     command_type: hikari.CommandType
     group: str | None
     sub_group: str | None
     options: dict[str, Any]
+    """The options that were provided by the user."""
+
+
+@define
+class Context(BaseContext):
+    """Represents the context for command interactions"""
+
+    interaction: CommandInteraction
 
     _has_replied: bool = False
     _used_first_resp: bool = False
@@ -259,3 +279,7 @@ class Context:
         await self.app.rest.delete_interaction_response(
             application=self.application_id, token=self.token
         )
+
+
+class AutocompleteContext(BaseContext):
+    """Represents the context for autocomplete interactions"""

--- a/crescent/context.py
+++ b/crescent/context.py
@@ -81,8 +81,6 @@ class BaseContext:
 class Context(BaseContext):
     """Represents the context for command interactions"""
 
-    interaction: CommandInteraction
-
     _has_replied: bool = False
     _used_first_resp: bool = False
 

--- a/crescent/context.py
+++ b/crescent/context.py
@@ -19,7 +19,7 @@ from hikari import (
 from crescent.utils import map_or
 
 if TYPE_CHECKING:
-    from typing import Any, Literal, Sequence, Type, TypeVar
+    from typing import Any, Literal, Sequence
 
     from hikari import (
         CommandInteraction,
@@ -36,8 +36,6 @@ if TYPE_CHECKING:
     from hikari.api import ComponentBuilder
 
     from crescent.bot import Bot
-
-    ContextT = TypeVar("ContextT", bound="BaseContext")
 
 
 __all__: Sequence[str] = ("Context", "AutocompleteContext")
@@ -78,27 +76,6 @@ class BaseContext:
     sub_group: str | None
     options: dict[str, Any]
     """The options that were provided by the user."""
-
-    # Mypy is too dumb for lowercase type to work here
-    def _into_subclass(self, ctx_type: Type[ContextT]) -> ContextT:
-        return ctx_type(
-            interaction=self.interaction,
-            app=self.app,
-            application_id=self.application_id,
-            type=self.type,
-            token=self.token,
-            id=self.id,
-            version=self.version,
-            channel_id=self.channel_id,
-            guild_id=self.guild_id,
-            user=self.user,
-            member=self.member,
-            command=self.command,
-            group=self.group,
-            sub_group=self.sub_group,
-            command_type=self.command_type,
-            options=self.options,
-        )
 
 
 @define

--- a/crescent/context/__init__.py
+++ b/crescent/context/__init__.py
@@ -1,0 +1,8 @@
+from typing import Sequence
+
+from crescent.context.base_context import *
+from crescent.context.context import *
+from crescent.context.autocomplete_context import *
+
+
+__all__: Sequence[str] = ("BaseContext", "Context", "AutocompleteContext")

--- a/crescent/context/__init__.py
+++ b/crescent/context/__init__.py
@@ -1,8 +1,7 @@
 from typing import Sequence
 
+from crescent.context.autocomplete_context import *
 from crescent.context.base_context import *
 from crescent.context.context import *
-from crescent.context.autocomplete_context import *
-
 
 __all__: Sequence[str] = ("BaseContext", "Context", "AutocompleteContext")

--- a/crescent/context/autocomplete_context.py
+++ b/crescent/context/autocomplete_context.py
@@ -1,0 +1,12 @@
+from typing import Sequence
+
+from hikari import CommandInteraction
+
+from crescent.context.base_context import BaseContext
+
+__all__: Sequence[str] = ("AutocompleteContext",)
+
+class AutocompleteContext(BaseContext):
+    """Represents the context for autocomplete interactions"""
+
+    interaction: CommandInteraction

--- a/crescent/context/autocomplete_context.py
+++ b/crescent/context/autocomplete_context.py
@@ -6,6 +6,7 @@ from crescent.context.base_context import BaseContext
 
 __all__: Sequence[str] = ("AutocompleteContext",)
 
+
 class AutocompleteContext(BaseContext):
     """Represents the context for autocomplete interactions"""
 

--- a/crescent/context/base_context.py
+++ b/crescent/context/base_context.py
@@ -4,12 +4,7 @@ from typing import TYPE_CHECKING
 
 import hikari
 from attr import define
-from hikari import (
-    Member,
-    PartialInteraction,
-    Snowflake,
-    User,
-)
+from hikari import Member, PartialInteraction, Snowflake, User
 
 if TYPE_CHECKING:
     from typing import Any, Sequence

--- a/crescent/context/base_context.py
+++ b/crescent/context/base_context.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import hikari
+from attr import define
+from hikari import (
+    Member,
+    PartialInteraction,
+    Snowflake,
+    User,
+)
+
+if TYPE_CHECKING:
+    from typing import Any, Sequence
+
+    from crescent.bot import Bot
+
+
+__all__: Sequence[str] = ("BaseContext",)
+
+
+@define
+class BaseContext:
+    """Represents the context for interactions"""
+
+    interaction: PartialInteraction
+    """The interaction object."""
+    app: Bot
+    """The application instance."""
+    application_id: Snowflake
+    """The ID for the client that this interaction belongs to."""
+    type: int
+    """The type of the interaction."""
+    token: str
+    """The token for the interaction."""
+    id: Snowflake
+    """The ID of the interaction."""
+    version: int
+    """Version of the interaction system this interaction is under."""
+
+    channel_id: Snowflake
+    """The channel ID of the channel that the interaction was used in."""
+    guild_id: Snowflake | None
+    """The guild ID of the guild that this interaction was used in."""
+    user: User
+    """The user who triggered this command interaction."""
+    member: Member | None
+    """The member object for the user that triggered this interaction, if used in a guild."""
+
+    command: str
+    """The name of the command."""
+    command_type: hikari.CommandType
+    group: str | None
+    sub_group: str | None
+    options: dict[str, Any]
+    """The options that were provided by the user."""

--- a/crescent/context/context.py
+++ b/crescent/context/context.py
@@ -2,21 +2,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, overload
 
-import hikari
 from attr import define
 from hikari import (
     UNDEFINED,
     Guild,
     GuildChannel,
-    Member,
     MessageFlag,
-    PartialInteraction,
     ResponseType,
-    Snowflake,
-    User,
 )
 
 from crescent.utils import map_or
+from crescent.context.base_context import BaseContext
 
 if TYPE_CHECKING:
     from typing import Any, Literal, Sequence
@@ -35,47 +31,8 @@ if TYPE_CHECKING:
     )
     from hikari.api import ComponentBuilder
 
-    from crescent.bot import Bot
 
-
-__all__: Sequence[str] = ("Context", "AutocompleteContext")
-
-
-@define
-class BaseContext:
-    """Represents the context for interactions"""
-
-    interaction: PartialInteraction
-    """The interaction object."""
-    app: Bot
-    """The application instance."""
-    application_id: Snowflake
-    """The ID for the client that this interaction belongs to."""
-    type: int
-    """The type of the interaction."""
-    token: str
-    """The token for the interaction."""
-    id: Snowflake
-    """The ID of the interaction."""
-    version: int
-    """Version of the interaction system this interaction is under."""
-
-    channel_id: Snowflake
-    """The channel ID of the channel that the interaction was used in."""
-    guild_id: Snowflake | None
-    """The guild ID of the guild that this interaction was used in."""
-    user: User
-    """The user who triggered this command interaction."""
-    member: Member | None
-    """The member object for the user that triggered this interaction, if used in a guild."""
-
-    command: str
-    """The name of the command."""
-    command_type: hikari.CommandType
-    group: str | None
-    sub_group: str | None
-    options: dict[str, Any]
-    """The options that were provided by the user."""
+__all__: Sequence[str] = ("Context",)
 
 
 @define
@@ -280,9 +237,3 @@ class Context(BaseContext):
         await self.app.rest.delete_interaction_response(
             application=self.application_id, token=self.token
         )
-
-
-class AutocompleteContext(BaseContext):
-    """Represents the context for autocomplete interactions"""
-
-    interaction: CommandInteraction

--- a/crescent/context/context.py
+++ b/crescent/context/context.py
@@ -3,16 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, overload
 
 from attr import define
-from hikari import (
-    UNDEFINED,
-    Guild,
-    GuildChannel,
-    MessageFlag,
-    ResponseType,
-)
+from hikari import UNDEFINED, Guild, GuildChannel, MessageFlag, ResponseType
 
-from crescent.utils import map_or
 from crescent.context.base_context import BaseContext
+from crescent.utils import map_or
 
 if TYPE_CHECKING:
     from typing import Any, Literal, Sequence

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -161,7 +161,7 @@ _VALUE_TYPE_LINK: dict[OptionType | int, str] = {
 
 
 class CrescentCommandData(NamedTuple):
-    """ "Represents the information format crescent needs to understand commands"""
+    """Represents the information crescent needs to understand commands"""
 
     command_name: str
     group: str | None

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -20,7 +20,7 @@ from crescent.mentionable import Mentionable
 from crescent.utils import unwrap
 
 if TYPE_CHECKING:
-    from typing import Any, Sequence, TypeVar
+    from typing import Any, Sequence
 
     from hikari import (
         CommandInteraction,
@@ -33,8 +33,6 @@ if TYPE_CHECKING:
     from crescent.bot import Bot
     from crescent.internal import AppCommandMeta, Includable
     from crescent.typedefs import HookCallbackT, OptionTypesT
-
-    ContextT = TypeVar("ContextT", bound=BaseContext)
 
 
 _log = getLogger(__name__)
@@ -68,12 +66,11 @@ async def handle_resp(event: InteractionCreateEvent) -> None:
         return
 
     if interaction.type is InteractionType.AUTOCOMPLETE:
-        await _handle_autocomplete_resp(
-            command, _base_context_to_subclass(ctx, AutocompleteContext)
-        )
+        await _handle_autocomplete_resp(command, ctx._into_subclass(AutocompleteContext))
+
         return
 
-    await _handle_slash_resp(bot, command, _base_context_to_subclass(ctx, Context))
+    await _handle_slash_resp(bot, command, ctx._into_subclass(Context))
 
 
 async def _handle_hooks(hooks: Sequence[HookCallbackT], ctx: Context) -> bool:
@@ -199,27 +196,6 @@ def _base_context_from_interaction_resp(interaction: CommandInteraction) -> Base
         sub_group=sub_group,
         command_type=CommandType(interaction.command_type),
         options=callback_options,
-    )
-
-
-def _base_context_to_subclass(ctx: BaseContext, ctx_type: type[ContextT]) -> ContextT:
-    return ctx_type(
-        interaction=ctx.interaction,
-        app=ctx.app,
-        application_id=ctx.application_id,
-        type=ctx.type,
-        token=ctx.token,
-        id=ctx.id,
-        version=ctx.version,
-        channel_id=ctx.channel_id,
-        guild_id=ctx.guild_id,
-        user=ctx.user,
-        member=ctx.member,
-        command=ctx.command,
-        group=ctx.group,
-        sub_group=ctx.sub_group,
-        command_type=ctx.command_type,
-        options=ctx.options,
     )
 
 

--- a/crescent/typedefs.py
+++ b/crescent/typedefs.py
@@ -26,7 +26,7 @@ from hikari import (
 
 if TYPE_CHECKING:
     from crescent.commands.hooks import HookResult
-    from crescent.context import Context
+    from crescent.context import Context, AutocompleteContext
     from crescent.mentionable import Mentionable
 
 __all__: Sequence[str] = (
@@ -49,7 +49,7 @@ OptionTypesT = Union[str, bool, int, float, PartialChannel, Role, User, "Mention
 CommandOptionsT = Dict[str, Union[OptionTypesT, User, Message]]
 HookCallbackT = Callable[["Context"], Awaitable[Optional["HookResult"]]]
 AutocompleteCallbackT = Callable[
-    ["Context", AutocompleteInteractionOption], Awaitable[Sequence[CommandChoice]]
+    ["AutocompleteContext", AutocompleteInteractionOption], Awaitable[Sequence[CommandChoice]]
 ]
 
 PluginCallbackT = Callable[[], None]

--- a/examples/basic/autocomplete.py
+++ b/examples/basic/autocomplete.py
@@ -9,7 +9,7 @@ bot = crescent.Bot(token="...")
 
 
 async def autocomplete_response(
-    ctx: crescent.Context, option: hikari.AutocompleteInteractionOption
+    ctx: crescent.AutocompleteContext, option: hikari.AutocompleteInteractionOption
 ) -> Sequence[hikari.CommandChoice]:
     # All the other options are stored in ctx.options
     return [hikari.CommandChoice(name="Some Option", value="1234")]

--- a/examples/error_handling/basic.py
+++ b/examples/error_handling/basic.py
@@ -63,7 +63,7 @@ async def raise_error_event(event: hikari.MessageCreateEvent) -> None:
 
 
 async def autocomplete(
-    ctx: crescent.Context, option: hikari.AutocompleteInteractionOption
+    ctx: crescent.AutocompleteContext, option: hikari.AutocompleteInteractionOption
 ) -> list[hikari.CommandChoice]:
     assert isinstance(option.value, str)
     if option.value == "unhandled":


### PR DESCRIPTION
I spent a long time thinking about the implementation and this was the best I could think of

Breaking change. Requires the user to change the `crescent.Context` typehint to `crescent. AutocompleteContext` for autocomplete commands.

This system can easily be extended to allow users to use custom context types. (I think this system will add more complexity then its worth though, just want to keep the option open)