### PR TITLE
:bug: Remove inheritance from hikari builders

### DIFF
--- a/crescent/exceptions.py
+++ b/crescent/exceptions.py
@@ -17,10 +17,3 @@ class AlreadyRegisteredError(CrescentException):
 
 class PluginAlreadyLoadedError(CrescentException):
     """A plugin is attempted to be loaded but the plugin manager already loaded the plugin."""
-
-
-class HikariMoment(NotImplementedError):
-    """Hikari added an abstract method that's useless in this project."""
-
-    def __init__(self) -> None:
-        super().__init__("This method is not implemented because its not currently used.")

--- a/crescent/internal/app_command.py
+++ b/crescent/internal/app_command.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, TypeVar
 
 from attr import define, field
 from hikari import UNDEFINED, CommandOption, Permissions, Snowflakeish
-from hikari.api import CommandBuilder, EntityFactory
+from hikari.api import EntityFactory
 
 from crescent.context.utils import support_custom_context
 
@@ -13,16 +13,11 @@ if TYPE_CHECKING:
 
     from hikari import (
         CommandType,
-        PartialApplication,
-        PartialCommand,
-        PartialGuild,
         Snowflake,
-        SnowflakeishOr,
         UndefinedNoneOr,
         UndefinedOr,
         UndefinedType,
     )
-    from hikari.api.rest import RESTClient
 
     from crescent.commands.groups import Group, SubGroup
     from crescent.internal.includable import Includable

--- a/crescent/internal/app_command.py
+++ b/crescent/internal/app_command.py
@@ -11,13 +11,7 @@ from crescent.context.utils import support_custom_context
 if TYPE_CHECKING:
     from typing import Any, Sequence, Type
 
-    from hikari import (
-        CommandType,
-        Snowflake,
-        UndefinedNoneOr,
-        UndefinedOr,
-        UndefinedType,
-    )
+    from hikari import CommandType, Snowflake, UndefinedNoneOr, UndefinedOr, UndefinedType
 
     from crescent.commands.groups import Group, SubGroup
     from crescent.internal.includable import Includable

--- a/crescent/internal/app_command.py
+++ b/crescent/internal/app_command.py
@@ -7,7 +7,6 @@ from hikari import UNDEFINED, CommandOption, Permissions, Snowflakeish
 from hikari.api import CommandBuilder, EntityFactory
 
 from crescent.context.utils import support_custom_context
-from crescent.exceptions import HikariMoment
 
 if TYPE_CHECKING:
     from typing import Any, Sequence, Type
@@ -78,7 +77,7 @@ __all__: Sequence[str] = ("AppCommandMeta", "AppCommand")
 
 
 @define
-class AppCommand(CommandBuilder):
+class AppCommand:
     """Local representation of an Application Command"""
 
     type: CommandType
@@ -139,30 +138,6 @@ class AppCommand(CommandBuilder):
         out["dm_permission"] = self.is_dm_enabled
 
         return out
-
-    def set_id(self, _id: UndefinedOr[Snowflakeish]) -> AppCommand:
-        if isinstance(_id, int):
-            _id = Snowflake(_id)
-        self.id = _id
-        return self
-
-    def set_is_dm_enabled(self: Self, state: UndefinedOr[bool], /) -> Self:  # noqa
-        raise HikariMoment()
-
-    async def create(  # noqa
-        self,
-        rest: RESTClient,
-        application: SnowflakeishOr[PartialApplication],
-        /,
-        *,
-        guild: UndefinedOr[SnowflakeishOr[PartialGuild]] = UNDEFINED,
-    ) -> PartialCommand:
-        raise HikariMoment()
-
-    def set_default_member_permissions(  # noqa
-        self: Self, default_member_permissions: UndefinedType | int | Permissions, /
-    ) -> Self:
-        raise HikariMoment()
 
 
 @define

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from hikari import Snowflakeish
 
     from crescent.bot import Bot
-    from crescent.typedefs import AutocompleteCallbackT, CommandCallbackT, CanBuild
+    from crescent.typedefs import AutocompleteCallbackT, CanBuild, CommandCallbackT
 
     T = TypeVar("T", bound="Callable[..., Awaitable[Any]]")
 
@@ -265,9 +265,7 @@ class CommandHandler:
 
         return tuple(built_commands.values())
 
-    async def post_guild_commands(
-        self, commands: Sequence[CanBuild], guild: Snowflakeish
-    ) -> None:
+    async def post_guild_commands(self, commands: Sequence[CanBuild], guild: Snowflakeish) -> None:
         try:
             if self.application_id is None:
                 raise AttributeError("Client `application_id` is not defined")

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from hikari import Snowflakeish
 
     from crescent.bot import Bot
-    from crescent.typedefs import AutocompleteCallbackT, CanBuild
+    from crescent.typedefs import AutocompleteCallbackT, CommandCallbackT, CanBuild
 
     T = TypeVar("T", bound="Callable[..., Awaitable[Any]]")
 

--- a/crescent/typedefs.py
+++ b/crescent/typedefs.py
@@ -24,6 +24,7 @@ from hikari import (
     Role,
     User,
 )
+from hikari.api import EntityFactory
 
 if TYPE_CHECKING:
     from crescent.commands.hooks import HookResult
@@ -72,3 +73,8 @@ EventErrorHandlerCallbackT = Callable[[ERROR, Event], Awaitable[None]]
 AutocompleteErrorHandlerCallbackT = Callable[
     [ERROR, Any, AutocompleteInteractionOption], Awaitable[None]
 ]
+
+
+class CanBuild(Protocol):
+    def build(self, encoder: EntityFactory) -> dict[str, Any]:
+        ...


### PR DESCRIPTION
This will stop `crescent` from breaking whenever there is a change to builders. Specific types of builders were not type safe anyway so I dont think this PR removes any type safety.