### PR TITLE
Add --check flags to nox pipeline

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -33,8 +33,8 @@ def pip_session(*args: str, name: str | None = None) -> typing.Callable[[nox.Ses
 
 @pip_session("black", "isort", "codespell", name="apply-lint")
 def apply_lint(session: nox.Session) -> None:
-    session.run("black", "crescent")
-    session.run("isort", "crescent")
+    session.run("black", "crescent", "--check")
+    session.run("isort", "crescent", "--check")
     session.run("codespell", "crescent", "-i", "2")
 
 


### PR DESCRIPTION
It doesn't work to just *also* have --check, because no matter how you order it, something bad happens:
 - format, then check: It will format, and then the check will pass. CI will not fail.
 - check, then format: The pipeline will fail before it formats it, so the formatting is never run in the first place and don't do anything.