### PR TITLE
:sparkles: Add purge_commands method to CommandHandler

### DIFF
--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -308,10 +308,10 @@ class CommandHandler:
         Kwargs:
             skip_global:
                 If `True`, skip purging global commands.
-                Defaults to `False`.
             purge_everything:
                 If `True`, purge all global commands and commands in
-                all `tracked_guilds`. Defaults to `True`.
+                all `tracked_guilds`. This option takes priority over
+                `skip_global`.
         """
         if self._application_id is None:
             raise AttributeError("Client `application_id` is not defined")

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -319,6 +319,7 @@ class CommandHandler:
         if not skip_global or purge_everything:
             await self._bot.rest.set_application_commands(self._application_id, ())
 
+        guilds_to_purge: Iterable[PartialGuild | Snowflake | int]
         if purge_everything:
             guilds_to_purge = {*guilds, *self._guilds}
         else:

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -300,12 +300,11 @@ class CommandHandler:
         skip_global: bool = False,
         purge_everything: bool = True,
     ) -> None:
-        """
-        Purge application commands for this Command Handler.
+        """Purge application commands for this Command Handler.
 
         Args:
-            *guilds:
-                The guilds to purge commands from, if any.
+            *guilds: The guilds to purge commands from, if any.
+
         Kwargs:
             skip_global:
                 If `True`, skip purging global commands.


### PR DESCRIPTION
This PR adds a new method `purge_commands` onto `CommandHandler`.

By default it will purge all global commands and all commands in `tracked_guilds` with kwargs to alter that behavior.