### PR TITLE
:green_heart: Make pdoc build with python3.10

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: Setup Poetry
         uses: abatilo/actions-poetry@v2.1.3
       - name: Build docs


### PR DESCRIPTION
The type hints look better in the docs because they can be parsed by pdoc