### PR TITLE
:sparkles: Add Locale Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 ## Features
  - Simple and intuitive API.
  - Slash, user, and message commands.
+ - Command localization.
  - Error handling for commands, events, and autocomplete.
  - Hooks to run function before or after a command (or any command from a group!)
  - Plugin system to easily split bot into different modules.

--- a/crescent/__init__.py
+++ b/crescent/__init__.py
@@ -7,6 +7,7 @@ from crescent.context import *
 from crescent.errors import *
 from crescent.event import *
 from crescent.exceptions import *
+from crescent.locale import *
 from crescent.mentionable import *
 from crescent.plugin import *
 from crescent.typedefs import *
@@ -40,6 +41,7 @@ __all__: Sequence[str] = (
     "CrescentException",
     "AlreadyRegisteredError",
     "PluginAlreadyLoadedError",
+    "LocaleBuilder",
     "Mentionable",
     "CommandCallbackT",
     "CommandOptionsT",

--- a/crescent/commands/args.py
+++ b/crescent/commands/args.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 from attr import define
 from hikari import ChannelType, CommandChoice
 
+from crescent.locale import LocaleBuilder
+
 if TYPE_CHECKING:
     from typing import Any, Sequence
 
@@ -34,19 +36,19 @@ class Arg(ABC):
 
 @define(hash=True)
 class Description(Arg):
-    description: str
+    description: str | LocaleBuilder
 
     @property
-    def payload(self) -> str:
+    def payload(self) -> str | LocaleBuilder:
         return self.description
 
 
 @define(hash=True)
 class Name(Arg):
-    name: str
+    name: str | LocaleBuilder
 
     @property
-    def payload(self) -> str:
+    def payload(self) -> str | LocaleBuilder:
         return self.name
 
 

--- a/crescent/commands/decorators.py
+++ b/crescent/commands/decorators.py
@@ -10,6 +10,7 @@ from sigparse import sigparse
 from crescent.commands.options import ClassCommandOption
 from crescent.commands.signature import gen_command_option, get_autocomplete_func
 from crescent.internal.registry import register_command
+from crescent.locale import LocaleBuilder
 
 if TYPE_CHECKING:
     from typing import Any, Sequence, TypeVar
@@ -56,8 +57,8 @@ def command(callback: CommandCallbackT | type[ClassCommandProto], /) -> Includab
 def command(
     *,
     guild: Snowflakeish | None = ...,
-    name: str | None = ...,
-    description: str | None = ...,
+    name: str | LocaleBuilder | None = ...,
+    description: str | LocaleBuilder | None = ...,
     default_member_permissions: UndefinedType | int | Permissions = ...,
     dm_enabled: bool = ...,
 ) -> Callable[[CommandCallbackT | type[ClassCommandProto]], Includable[AppCommandMeta]]:
@@ -69,8 +70,8 @@ def command(
     /,
     *,
     guild: Snowflakeish | None = None,
-    name: str | None = None,
-    description: str | None = None,
+    name: str | LocaleBuilder | None = None,
+    description: str | LocaleBuilder | None = None,
     default_member_permissions: UndefinedType | int | Permissions = UNDEFINED,
     dm_enabled: bool = True,
 ) -> Includable[AppCommandMeta] | Callable[

--- a/crescent/commands/options.py
+++ b/crescent/commands/options.py
@@ -25,6 +25,7 @@ from hikari import (
     User,
 )
 
+from crescent.locale import LocaleBuilder, str_or_build_locale
 from crescent.mentionable import Mentionable
 
 if TYPE_CHECKING:
@@ -89,7 +90,7 @@ Self = TypeVar("Self")
 
 @dataclass
 class ClassCommandOption(Generic[T]):
-    name: str | None
+    name: str | LocaleBuilder | None
     type: OptionType
     description: str
     default: UndefinedNoneOr[Any]
@@ -102,10 +103,15 @@ class ClassCommandOption(Generic[T]):
     autocomplete: AutocompleteCallbackT | None
 
     def _gen_option(self, name: str) -> CommandOption:
+        name, name_localizations = str_or_build_locale(self.name or name)
+        description, description_localizations = str_or_build_locale(self.description)
+
         return CommandOption(
             type=self.type,
-            name=self.name or name,
-            description=self.description,
+            name=name,
+            name_localizations=name_localizations,
+            description=description,
+            description_localizations=description_localizations,
             is_required=self.default is UNDEFINED,
             choices=self.choices,
             channel_types=self.channel_types,

--- a/crescent/commands/options.py
+++ b/crescent/commands/options.py
@@ -92,7 +92,7 @@ Self = TypeVar("Self")
 class ClassCommandOption(Generic[T]):
     name: str | LocaleBuilder | None
     type: OptionType
-    description: str
+    description: str | LocaleBuilder
     default: UndefinedNoneOr[Any]
     choices: Sequence[CommandChoice] | None
     channel_types: Sequence[ChannelType] | None
@@ -150,9 +150,9 @@ ATTACHMENT = TypeVar("ATTACHMENT", bound="type[Attachment]")
 @overload
 def option(
     option_type: type[PartialChannel] | Sequence[type[PartialChannel]],
-    description: str = ...,
+    description: str | LocaleBuilder = ...,
     *,
-    name: str | None = ...,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[InteractionChannel]:
     ...
 
@@ -160,10 +160,10 @@ def option(
 @overload
 def option(
     option_type: type[PartialChannel] | Sequence[type[PartialChannel]],
-    description: str = ...,
+    description: str | LocaleBuilder = ...,
     *,
     default: DEFAULT,
-    name: str | None = ...,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[InteractionChannel | DEFAULT]:
     ...
 
@@ -172,8 +172,9 @@ def option(
 @overload
 def option(
     option_type: USER,  # pyright: ignore
-    description: str = ...,
-    *, name: str | None = ...,
+    description: str | LocaleBuilder = ...,
+    *,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[User]:
     ...
 # fmt: on
@@ -182,10 +183,10 @@ def option(
 @overload
 def option(
     option_type: USER,  # pyright: ignore
-    description: str = ...,
+    description: str | LocaleBuilder = ...,
     *,
     default: DEFAULT,
-    name: str | None = ...,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[User | DEFAULT]:
     ...
 
@@ -194,9 +195,9 @@ def option(
 @overload
 def option(
     option_type: ROLE,  # pyright: ignore
-    description: str = ...,
+    description: str | LocaleBuilder = ...,
     *,
-    name: str | None = ...,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[Role]:
     ...
 # fmt: on
@@ -205,10 +206,10 @@ def option(
 @overload
 def option(
     option_type: ROLE,  # pyright: ignore
-    description: str = ...,
+    description: str | LocaleBuilder = ...,
     *,
     default: DEFAULT,
-    name: str | None = ...,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[Role | DEFAULT]:
     ...
 
@@ -217,9 +218,9 @@ def option(
 @overload
 def option(
     option_type: ATTACHMENT,  # pyright: ignore
-    description: str = ...,
+    description: str | LocaleBuilder = ...,
     *,
-    name: str | None = ...,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[Attachment]:
     ...
 # fmt: on
@@ -228,17 +229,20 @@ def option(
 @overload
 def option(
     option_type: ATTACHMENT,  # pyright: ignore
-    description: str = ...,
+    description: str | LocaleBuilder = ...,
     *,
     default: DEFAULT,
-    name: str | None = ...,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[Attachment | DEFAULT]:
     ...
 
 
 @overload
 def option(
-    option_type: type[Mentionable], description: str = ..., *, name: str | None = ...
+    option_type: type[Mentionable],
+    description: str | LocaleBuilder = ...,
+    *,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[Mentionable]:
     ...
 
@@ -246,24 +250,31 @@ def option(
 @overload
 def option(
     option_type: type[Mentionable],
-    description: str = ...,
+    description: str | LocaleBuilder = ...,
     *,
     default: DEFAULT,
-    name: str | None = ...,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[Mentionable | DEFAULT]:
     ...
 
 
 @overload
 def option(  # type: ignore
-    option_type: type[bool], description: str = ..., *, name: str | None = ...
+    option_type: type[bool],
+    description: str | LocaleBuilder = ...,
+    *,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[bool]:
     ...
 
 
 @overload
 def option(  # type: ignore
-    option_type: type[bool], description: str = ..., *, default: DEFAULT, name: str | None = ...
+    option_type: type[bool],
+    description: str | LocaleBuilder = ...,
+    *,
+    default: DEFAULT,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[bool | DEFAULT]:
     ...
 
@@ -271,13 +282,13 @@ def option(  # type: ignore
 @overload
 def option(
     option_type: type[int],
-    description: str = ...,
+    description: str | LocaleBuilder = ...,
     *,
     choices: Sequence[tuple[str, int]] | None = ...,
     autocomplete: AutocompleteCallbackT | None = ...,
     min_value: int | None = ...,
     max_value: int | None = ...,
-    name: str | None = ...,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[int]:
     ...
 
@@ -285,14 +296,14 @@ def option(
 @overload
 def option(
     option_type: type[int],
-    description: str = ...,
+    description: str | LocaleBuilder = ...,
     *,
     default: DEFAULT,
     choices: Sequence[tuple[str, int]] | None = ...,
     autocomplete: AutocompleteCallbackT | None = ...,
     min_value: int | None = ...,
     max_value: int | None = ...,
-    name: str | None = ...,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[int | DEFAULT]:
     ...
 
@@ -300,13 +311,13 @@ def option(
 @overload
 def option(
     option_type: type[float],
-    description: str = ...,
+    description: str | LocaleBuilder = ...,
     *,
     choices: Sequence[tuple[str, float]] | None = ...,
     autocomplete: AutocompleteCallbackT | None = ...,
     min_value: float | None = ...,
     max_value: float | None = ...,
-    name: str | None = ...,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[float]:
     ...
 
@@ -314,14 +325,14 @@ def option(
 @overload
 def option(
     option_type: type[float],
-    description: str = ...,
+    description: str | LocaleBuilder = ...,
     *,
     default: DEFAULT,
     choices: Sequence[tuple[str, float]] | None = ...,
     autocomplete: AutocompleteCallbackT | None = ...,
     min_value: float | None = ...,
     max_value: float | None = ...,
-    name: str | None = ...,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[float | DEFAULT]:
     ...
 
@@ -329,13 +340,13 @@ def option(
 @overload
 def option(
     option_type: type[str],
-    description: str = ...,
+    description: str | LocaleBuilder = ...,
     *,
     min_length: int | None = ...,
     max_length: int | None = ...,
     choices: Sequence[tuple[str, str]] | None = ...,
     autocomplete: AutocompleteCallbackT | None = ...,
-    name: str | None = ...,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[str]:
     ...
 
@@ -343,21 +354,21 @@ def option(
 @overload
 def option(
     option_type: type[str],
-    description: str = ...,
+    description: str | LocaleBuilder = ...,
     *,
     default: DEFAULT,
     min_length: int | None = ...,
     max_length: int | None = ...,
     choices: Sequence[tuple[str, str]] | None = ...,
     autocomplete: AutocompleteCallbackT | None = ...,
-    name: str | None = ...,
+    name: str | LocaleBuilder | None = ...,
 ) -> ClassCommandOption[str | DEFAULT]:
     ...
 
 
 def option(
     option_type: type[OptionTypesT] | Sequence[type[PartialChannel]],
-    description: str = "No Description",
+    description: str | LocaleBuilder = "No Description",
     *,
     default: UndefinedOr[Any] = UNDEFINED,
     choices: Sequence[tuple[str, str | int | float]] | None = None,
@@ -365,7 +376,7 @@ def option(
     max_value: int | float | None = None,
     min_length: int | None = None,
     max_length: int | None = None,
-    name: str | None = None,
+    name: str | LocaleBuilder | None = None,
     autocomplete: AutocompleteCallbackT | None = None,
 ) -> ClassCommandOption[Any]:
 

--- a/crescent/commands/signature.py
+++ b/crescent/commands/signature.py
@@ -19,6 +19,7 @@ from crescent.commands.args import (
 )
 from crescent.commands.options import OPTIONS_TYPE_MAP, get_channel_types
 from crescent.context import BaseContext
+from crescent.locale import LocaleBuilder, str_or_build_locale
 from crescent.utils import any_issubclass
 
 if TYPE_CHECKING:
@@ -91,7 +92,16 @@ def gen_command_option(param: Parameter) -> CommandOption | None:
         )
 
     name = _get_arg(Name, metadata) or param.name
-    description = _get_arg(Description, metadata) or _get_arg(str, metadata) or "No Description"
+    description = (
+        _get_arg(Description, metadata)
+        or _get_arg(str, metadata)
+        or _get_arg(LocaleBuilder, metadata)
+        or "No Description"
+    )
+
+    name, name_localizations = str_or_build_locale(name)
+    description, description_localizations = str_or_build_locale(name)
+
     choices = _get_arg(Choices, metadata)
     channel_types = _channel_types or _get_arg(ChannelTypes, metadata)
     min_value = _get_arg(MinValue, metadata)
@@ -104,9 +114,11 @@ def gen_command_option(param: Parameter) -> CommandOption | None:
 
     return CommandOption(
         name=name,
+        name_localizations=name_localizations,
         autocomplete=bool(autocomplete),
         type=_type,
         description=description,
+        description_localizations=description_localizations,
         choices=choices,
         options=None,
         channel_types=list(channel_types) if channel_types else None,

--- a/crescent/commands/signature.py
+++ b/crescent/commands/signature.py
@@ -100,7 +100,7 @@ def gen_command_option(param: Parameter) -> CommandOption | None:
     )
 
     name, name_localizations = str_or_build_locale(name)
-    description, description_localizations = str_or_build_locale(name)
+    description, description_localizations = str_or_build_locale(description)
 
     choices = _get_arg(Choices, metadata)
     channel_types = _channel_types or _get_arg(ChannelTypes, metadata)

--- a/crescent/context/base_context.py
+++ b/crescent/context/base_context.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import hikari
 from attr import define
-from hikari import Member, PartialInteraction, Snowflake, User
+from hikari import Member, PartialInteraction, Snowflake, User, Locale
 
 if TYPE_CHECKING:
     from typing import Any, Sequence, Type, TypeVar
@@ -44,6 +44,7 @@ class BaseContext:
     """The user who triggered this command interaction."""
     member: Member | None
     """The member object for the user that triggered this interaction, if used in a guild."""
+    locale: Locale
 
     command: str
     """The name of the command."""
@@ -87,6 +88,7 @@ class BaseContext:
             guild_id=self.guild_id,
             user=self.user,
             member=self.member,
+            locale=self.locale,
             command=self.command,
             command_type=self.command_type,
             group=self.group,

--- a/crescent/context/base_context.py
+++ b/crescent/context/base_context.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import hikari
 from attr import define
-from hikari import Member, PartialInteraction, Snowflake, User, Locale
+from hikari import Locale, Member, PartialInteraction, Snowflake, User
 
 if TYPE_CHECKING:
     from typing import Any, Sequence, Type, TypeVar

--- a/crescent/internal/app_command.py
+++ b/crescent/internal/app_command.py
@@ -7,6 +7,7 @@ from hikari import UNDEFINED, CommandOption, Permissions, Snowflakeish
 from hikari.api import EntityFactory
 
 from crescent.context.utils import support_custom_context
+from crescent.locale import LocaleBuilder, str_or_build_locale
 
 if TYPE_CHECKING:
     from typing import Any, Sequence, Type
@@ -44,7 +45,7 @@ class Unique:
     @classmethod
     def from_meta_struct(cls: Type[Unique], command: Includable[AppCommandMeta]) -> Unique:
         return cls(
-            name=command.metadata.app_command.name,
+            name=str_or_build_locale(command.metadata.app_command.name)[0],
             type=command.metadata.app_command.type,
             guild_id=command.metadata.app_command.guild_id,
             group=command.metadata.group.name if command.metadata.group else None,
@@ -54,7 +55,7 @@ class Unique:
     @classmethod
     def from_app_command_meta(cls: Type[Unique], command: AppCommandMeta) -> Unique:
         return cls(
-            name=command.app_command.name,
+            name=str_or_build_locale(command.app_command.name)[0],
             type=command.app_command.type,
             guild_id=command.app_command.guild_id,
             group=command.group.name if command.group else None,
@@ -70,10 +71,10 @@ class AppCommand:
     """Local representation of an Application Command"""
 
     type: CommandType
-    name: str
+    name: str | LocaleBuilder
     guild_id: Snowflakeish | None
 
-    description: str | None = None
+    description: str | LocaleBuilder | None = None
     options: Sequence[CommandOption] | None = None
     default_member_permissions: UndefinedType | int | Permissions = UNDEFINED
     is_dm_enabled: bool = True
@@ -108,10 +109,18 @@ class AppCommand:
         return self.guild_id == o.guild_id and self.name == o.name and self.type == o.type
 
     def build(self, encoder: EntityFactory) -> dict[str, Any]:
-        out: dict[str, Any] = {"name": self.name, "type": self.type}
+        name, name_localizations = str_or_build_locale(self.name)
+
+        out: dict[str, Any] = {
+            "name": name,
+            "name_localizations": name_localizations,
+            "type": self.type,
+        }
 
         if self.description:
-            out["description"] = self.description
+            description, description_localizations = str_or_build_locale(self.description)
+            out["description"] = description
+            out["description_localizations"] = description_localizations
         if self.options:
             out["options"] = [encoder.serialize_command_option(option) for option in self.options]
 
@@ -162,7 +171,7 @@ class AppCommandMeta:
     @property
     def unique(self) -> Unique:
         return Unique(
-            self.app_command.name,
+            str_or_build_locale(self.app_command.name)[0],
             self.app_command.type,
             self.app_command.guild_id,
             self.group.name if self.group else None,

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -12,6 +12,7 @@ from hikari import (
     CommandType,
     InteractionType,
     OptionType,
+    Locale,
     Snowflake,
 )
 
@@ -221,6 +222,7 @@ def _context_from_interaction_resp(
         guild_id=interaction.guild_id,
         user=interaction.user,
         member=interaction.member,
+        locale=Locale(interaction.locale),
         command=command_name,
         group=group,
         sub_group=sub_group,

--- a/crescent/internal/handle_resp.py
+++ b/crescent/internal/handle_resp.py
@@ -11,8 +11,8 @@ from hikari import (
     CommandInteraction,
     CommandType,
     InteractionType,
-    OptionType,
     Locale,
+    OptionType,
     Snowflake,
 )
 

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -22,6 +22,7 @@ from crescent.context.utils import support_custom_context
 from crescent.exceptions import AlreadyRegisteredError
 from crescent.internal.app_command import AppCommand, AppCommandMeta, Unique
 from crescent.internal.includable import Includable
+from crescent.locale import LocaleBuilder, str_or_build_locale
 from crescent.utils import gather_iter, unwrap
 
 if TYPE_CHECKING:
@@ -49,9 +50,9 @@ def register_command(
     owner: Any,
     callback: CommandCallbackT,
     command_type: CommandType,
-    name: str,
+    name: str | LocaleBuilder,
     guild: Snowflakeish | None = None,
-    description: str | None = None,
+    description: str | LocaleBuilder | None = None,
     options: Sequence[CommandOption] | None = None,
     default_member_permissions: UndefinedType | int | Permissions = UNDEFINED,
     dm_enabled: bool = True,
@@ -209,10 +210,18 @@ class CommandHandler:
                 else:
                     children.append(sub_command_group)
 
+                name, name_localizations = str_or_build_locale(command.metadata.app_command.name)
+                assert command.metadata.app_command.description
+                description, description_localizations = str_or_build_locale(
+                    command.metadata.app_command.description
+                )
+
                 cast("list[CommandOption]", sub_command_group.options).append(
                     CommandOption(
-                        name=command.metadata.app_command.name,
-                        description=unwrap(command.metadata.app_command.description),
+                        name=name,
+                        name_localizations=name_localizations,
+                        description=description,
+                        description_localizations=description_localizations,
                         type=OptionType.SUB_COMMAND,
                         options=command.metadata.app_command.options,
                         is_required=False,
@@ -253,10 +262,18 @@ class CommandHandler:
 
                 # No checking has to be done before appending `command` since it is the
                 # lowest level.
+                name, name_localizations = str_or_build_locale(command.metadata.app_command.name)
+                assert command.metadata.app_command.description
+                description, description_localizations = str_or_build_locale(
+                    command.metadata.app_command.description
+                )
+
                 cast("list[CommandOption]", built_commands[key].options).append(
                     CommandOption(
-                        name=command.metadata.app_command.name,
-                        description=unwrap(command.metadata.app_command.description),
+                        name=name,
+                        name_localizations=name_localizations,
+                        description=description,
+                        description_localizations=description_localizations,
                         type=command.metadata.app_command.type,
                         options=command.metadata.app_command.options,
                         is_required=False,

--- a/crescent/locale.py
+++ b/crescent/locale.py
@@ -14,7 +14,7 @@ class LocaleBuilder(ABC):
         language codes to strings.
 
         [Discord API Docs Localization.](https://discord.com/developers/docs/interactions/application-commands#localization)
-        """
+        """  # noqa: E501
 
     @property
     @abstractmethod

--- a/crescent/locale.py
+++ b/crescent/locale.py
@@ -16,8 +16,9 @@ class LocaleBuilder(ABC):
         [Discord API Docs Localization.](https://discord.com/developers/docs/interactions/application-commands#localization)
         """
 
+    @property
     @abstractmethod
-    def default(self) -> str:
+    def fallback(self) -> str:
         """Return the name used when there is no localization for a language."""
 
 
@@ -25,6 +26,6 @@ def str_or_build_locale(
     string_or_locale: str | LocaleBuilder,
 ) -> tuple[str, MutableMapping[str, str]]:
     if isinstance(string_or_locale, LocaleBuilder):
-        return (string_or_locale.default(), string_or_locale.build())
+        return (string_or_locale.fallback, string_or_locale.build())
     else:
         return (string_or_locale, {})

--- a/crescent/locale.py
+++ b/crescent/locale.py
@@ -17,7 +17,7 @@ class LocaleBuilder(ABC):
         """
 
     @abstractmethod
-    def default_name(self) -> str:
+    def default(self) -> str:
         """Return the name used when there is no localization for a language."""
 
 
@@ -25,6 +25,6 @@ def str_or_build_locale(
     string_or_locale: str | LocaleBuilder,
 ) -> tuple[str, MutableMapping[str, str]]:
     if isinstance(string_or_locale, LocaleBuilder):
-        return (string_or_locale.default_name(), string_or_locale.build())
+        return (string_or_locale.default(), string_or_locale.build())
     else:
         return (string_or_locale, {})

--- a/crescent/locale.py
+++ b/crescent/locale.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import MutableMapping, Sequence
 
-
-__all__: Sequence[str] = ("LocaleBuilder", "build_str_or_locale")
+__all__: Sequence[str] = ("LocaleBuilder", "str_or_build_locale")
 
 
 class LocaleBuilder(ABC):
@@ -14,7 +13,7 @@ class LocaleBuilder(ABC):
         Builds the locales for a command. Returns a `MutableMapping` of
         language codes to strings.
 
-        [Discord API Docs on Localization](https://discord.com/developers/docs/interactions/application-commands#localization)
+        [Discord API Docs Localization.](https://discord.com/developers/docs/interactions/application-commands#localization)
         """
 
     @abstractmethod
@@ -22,7 +21,7 @@ class LocaleBuilder(ABC):
         """Return the name used when there is no localization for a language."""
 
 
-def build_str_or_locale(
+def str_or_build_locale(
     string_or_locale: str | LocaleBuilder,
 ) -> tuple[str, MutableMapping[str, str]]:
     if isinstance(string_or_locale, LocaleBuilder):

--- a/crescent/locale.py
+++ b/crescent/locale.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import MutableMapping, Sequence
+
+
+__all__: Sequence[str] = ("LocaleBuilder", "build_str_or_locale")
+
+
+class LocaleBuilder(ABC):
+    @abstractmethod
+    def build(self) -> MutableMapping[str, str]:
+        """
+        Builds the locales for a command. Returns a `MutableMapping` of
+        language codes to strings.
+
+        [Discord API Docs on Localization](https://discord.com/developers/docs/interactions/application-commands#localization)
+        """
+
+    @abstractmethod
+    def default_name(self) -> str:
+        """Return the name used when there is no localization for a language."""
+
+
+def build_str_or_locale(
+    string_or_locale: str | LocaleBuilder,
+) -> tuple[str, MutableMapping[str, str]]:
+    if isinstance(string_or_locale, LocaleBuilder):
+        return (string_or_locale.default_name(), string_or_locale.build())
+    else:
+        return (string_or_locale, {})

--- a/crescent/locale.py
+++ b/crescent/locale.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import MutableMapping, Sequence
+from typing import Mapping, Sequence
 
 __all__: Sequence[str] = ("LocaleBuilder", "str_or_build_locale")
 
 
 class LocaleBuilder(ABC):
     @abstractmethod
-    def build(self) -> MutableMapping[str, str]:
+    def build(self) -> Mapping[str, str]:
         """
-        Builds the locales for a command. Returns a `MutableMapping` of
+        Builds the locales for a command. Returns a `Mapping` of
         language codes to strings.
 
         [Discord API Docs Localization.](https://discord.com/developers/docs/interactions/application-commands#localization)
@@ -22,9 +22,7 @@ class LocaleBuilder(ABC):
         """Return the name used when there is no localization for a language."""
 
 
-def str_or_build_locale(
-    string_or_locale: str | LocaleBuilder,
-) -> tuple[str, MutableMapping[str, str]]:
+def str_or_build_locale(string_or_locale: str | LocaleBuilder) -> tuple[str, Mapping[str, str]]:
     if isinstance(string_or_locale, LocaleBuilder):
         return (string_or_locale.fallback, string_or_locale.build())
     else:

--- a/examples/locales/basic.py
+++ b/examples/locales/basic.py
@@ -11,19 +11,18 @@ bot = crescent.Bot("...")
 @dataclasses.dataclass
 class Locale(crescent.LocaleBuilder):
 
-    default_name: str
+    _fallback: str
     en_US: str
 
     def build(self) -> typing.MutableMapping[str, str]:
         """Return a dict of command localization names to values."""
 
         # All possible locales can be seen in the `hikari.Locale` enum.
-        return {"en-US": "english-name"}
+        return {"en-US": self.en_US}
 
     @property
     def fallback(self) -> str:
-        "This value is used as the default."
-        return self.default_name
+        return self._fallback
 
 
 # This command's name is "en-name" for users on the `en-US` locale. Otherwise the

--- a/examples/locales/basic.py
+++ b/examples/locales/basic.py
@@ -14,7 +14,7 @@ class Locale(crescent.LocaleBuilder):
     _fallback: str
     en_US: str
 
-    def build(self) -> typing.MutableMapping[str, str]:
+    def build(self) -> typing.Mapping[str, str]:
         """Return a dict of command localization names to values."""
 
         # All possible locales can be seen in the `hikari.Locale` enum.

--- a/examples/locales/basic.py
+++ b/examples/locales/basic.py
@@ -31,7 +31,7 @@ class Locale(crescent.LocaleBuilder):
 @crescent.command(
     name=Locale("name", en_US="en-name"), description=Locale("description", en_US="en-description")
 )
-class command:
+class Command:
     # "en-option-name" and "en-option-description" will be used when the user is
     # using the `en-US` locale. Otherwise "option-name" and "option-description"
     # will be visible.

--- a/examples/locales/basic.py
+++ b/examples/locales/basic.py
@@ -17,6 +17,7 @@ class Locale(crescent.LocaleBuilder):
     def build(self) -> typing.MutableMapping[str, str]:
         """Return a dict of command localization names to values."""
 
+        # All possible locales can be seen in the `hikari.Locale` enum.
         return {"en-US": "english-name"}
 
     def default(self) -> str:

--- a/examples/locales/basic.py
+++ b/examples/locales/basic.py
@@ -1,8 +1,9 @@
 # Locales can be used by subclassing `crescent.LocaleBuilder`
 
+from __future__ import annotations
+
 import crescent
 import dataclasses
-import typing
 
 
 bot = crescent.Bot("...")
@@ -14,7 +15,8 @@ class Locale(crescent.LocaleBuilder):
     _fallback: str
     en_US: str
 
-    def build(self) -> typing.Mapping[str, str]:
+    # Build must return a subclass of `typing.Mapping`.
+    def build(self) -> dict[str, str]:
         """Return a dict of command localization names to values."""
 
         # All possible locales can be seen in the `hikari.Locale` enum.

--- a/examples/locales/basic.py
+++ b/examples/locales/basic.py
@@ -20,7 +20,8 @@ class Locale(crescent.LocaleBuilder):
         # All possible locales can be seen in the `hikari.Locale` enum.
         return {"en-US": "english-name"}
 
-    def default(self) -> str:
+    @property
+    def fallback(self) -> str:
         "This value is used as the default."
         return self.default_name
 

--- a/examples/locales/builder.py
+++ b/examples/locales/builder.py
@@ -1,0 +1,48 @@
+# Locales can be used by subclassing `crescent.LocaleBuilder`
+
+import crescent
+import dataclasses
+import typing
+
+
+bot = crescent.Bot("...")
+
+
+@dataclasses.dataclass
+class Locale(crescent.LocaleBuilder):
+
+    default_name: str
+    en_US: str
+
+    def build(self) -> typing.MutableMapping[str, str]:
+        """Return a dict of command localization names to values."""
+
+        return {"en-US": "english-name"}
+
+    def default(self) -> str:
+        "This value is used as the default."
+        return self.default_name
+
+
+# This command's name is "en-name" for users on the `en-US` locale. Otherwise the
+# command will be displayed as "name". The same pattern follows for the description.
+@bot.include
+@crescent.command(
+    name=Locale("name", en_US="en-name"), description=Locale("description", en_US="en-description")
+)
+class command:
+    # "en-option-name" and "en-option-description" will be used when the user is
+    # using the `en-US` locale. Otherwise "option-name" and "option-description"
+    # will be visible.
+    word = crescent.option(
+        str,
+        name=Locale("option-name", en_US="en-option-name"),
+        description=Locale("option-description", en_US="en-option-description"),
+    )
+
+    async def callback(self, ctx: crescent.Context) -> None:
+        # The locale of the user who ran the command can be viewed with `Context.locale`
+        await ctx.respond(ctx.locale)
+
+
+bot.run()

--- a/tests/crescent/commands/test_argparse.py
+++ b/tests/crescent/commands/test_argparse.py
@@ -27,8 +27,7 @@ from typing_extensions import Annotated
 from crescent import ChannelTypes, Choices, Description, MaxValue, MinValue, Name
 from crescent.commands.args import MaxLength, MinLength
 from crescent.commands.signature import gen_command_option
-from tests.utils import arrays_contain_same_elements
-
+from tests.utils import Locale, arrays_contain_same_elements
 
 global_PEP604()
 
@@ -63,6 +62,20 @@ def test_annotations():
         (
             Annotated[str, Name("different_name")],
             {"type": OptionType.STRING, "name": "different_name"},
+        ),
+        (
+            Annotated[
+                str,
+                Name(Locale("name", en_US="en-localization")),
+                Description(Locale("description", en_US="en-localization")),
+            ],
+            {
+                "type": OptionType.STRING,
+                "name": "name",
+                "name_localizations": {"en-US": "en-localization"},
+                "description": "description",
+                "description_localizations": {"en-US": "en-localization"},
+            },
         ),
         (
             Annotated[int, MinValue(10), MaxValue(15)],

--- a/tests/crescent/commands/test_argparse.py
+++ b/tests/crescent/commands/test_argparse.py
@@ -35,7 +35,7 @@ global_PEP604()
 POSITIONAL_OR_KEYWORD = _ParameterKind.POSITIONAL_OR_KEYWORD
 
 
-def testgen_command_option():
+def test_gen_command_option():
     assert (
         gen_command_option(
             Parameter(name="self", annotation=_empty, default=None, kind=POSITIONAL_OR_KEYWORD)

--- a/tests/crescent/commands/test_build.py
+++ b/tests/crescent/commands/test_build.py
@@ -12,8 +12,10 @@ def test_build():
         type=CommandType.SLASH, name="test_command", description="test description", guild_id=1234
     ).build(FACTORY) == {
         "name": "test_command",
+        "name_localizations": {},
         "type": CommandType.SLASH,
         "description": "test description",
+        "description_localizations": {},
         "default_member_permissions": None,
         "dm_permission": True,
     }
@@ -29,8 +31,10 @@ def test_build_with_perms():
         guild_id=1234,
     ).build(FACTORY) == {
         "name": "test_command",
+        "name_localizations": {},
         "type": CommandType.SLASH,
         "description": "test description",
+        "description_localizations": {},
         "default_member_permissions": str(Permissions.ATTACH_FILES.value),
         "dm_permission": False,
     }
@@ -44,8 +48,10 @@ def test_build_with_perms():
         guild_id=1234,
     ).build(FACTORY) == {
         "name": "test_command",
+        "name_localizations": {},
         "type": CommandType.SLASH,
         "description": "test description",
+        "description_localizations": {},
         "default_member_permissions": str(32768),
         "dm_permission": False,
     }

--- a/tests/crescent/ctx/test_autocomplete_ctx.py
+++ b/tests/crescent/ctx/test_autocomplete_ctx.py
@@ -1,11 +1,13 @@
 from copy import copy
 from unittest.mock import AsyncMock, Mock
+
+from hikari import CommandInteractionOption, InteractionType, OptionType
+from hikari.impl import CacheImpl, RESTClientImpl
+from pytest import mark
+
 from crescent import AutocompleteContext
-from hikari import InteractionType, CommandInteractionOption, OptionType
-from hikari.impl import RESTClientImpl, CacheImpl
 from crescent.mentionable import Mentionable
 from tests.utils import MockBot
-from pytest import mark
 
 options = [
     CommandInteractionOption(name="user", type=OptionType.USER, value=12345, options=None),

--- a/tests/crescent/ctx/test_autocomplete_ctx.py
+++ b/tests/crescent/ctx/test_autocomplete_ctx.py
@@ -40,6 +40,7 @@ ctx = AutocompleteContext(
     group=None,
     sub_group=None,
     member=None,
+    locale=None,
     command_type=None,
     options=None,
     has_created_message=None,

--- a/tests/crescent/ctx/test_ctx.py
+++ b/tests/crescent/ctx/test_ctx.py
@@ -16,13 +16,14 @@ def test_into():
         guild_id=9,
         user=10,
         member=11,
-        command=12,
-        command_type=13,
-        group=14,
-        sub_group=15,
-        options=16,
-        has_created_message=17,
-        has_deferred_response=18,
+        locale=12,
+        command=13,
+        command_type=14,
+        group=15,
+        sub_group=16,
+        options=17,
+        has_created_message=18,
+        has_deferred_response=19,
     )
 
     ctx2 = ctx.into(BaseContext)
@@ -38,6 +39,7 @@ def test_into():
     assert ctx.guild_id == ctx2.guild_id
     assert ctx.user == ctx2.user
     assert ctx.member == ctx2.member
+    assert ctx.locale == ctx2.locale
     assert ctx.command == ctx2.command
     assert ctx.command_type == ctx2.command_type
     assert ctx.group == ctx2.group
@@ -69,6 +71,7 @@ async def test_supports_context():
         guild_id=None,
         user=None,
         member=None,
+        locale=None,
         command=None,
         command_type=None,
         group=None,

--- a/tests/crescent/plugins/test_plugins.py
+++ b/tests/crescent/plugins/test_plugins.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from hikari import MessageCreateEvent
-from pytest import raises, LogCaptureFixture
+from pytest import LogCaptureFixture, raises
 
 from crescent.exceptions import PluginAlreadyLoadedError
 from tests.crescent.plugins.plugin import (

--- a/tests/crescent/test_locale.py
+++ b/tests/crescent/test_locale.py
@@ -1,0 +1,22 @@
+import crescent
+from crescent.locale import str_or_build_locale
+
+
+class TestBuilder(crescent.LocaleBuilder):
+    def build(self):
+        return "LOCALES"
+
+    def default(self):
+        return "DEFAULT"
+
+
+def test_str_or_build_locale():
+    default, locales = str_or_build_locale(TestBuilder())
+
+    assert default == "DEFAULT"
+    assert locales == "LOCALES"
+
+    default, locales = str_or_build_locale("test")
+
+    assert default == "test"
+    assert not locales

--- a/tests/crescent/test_locale.py
+++ b/tests/crescent/test_locale.py
@@ -1,20 +1,12 @@
-import crescent
 from crescent.locale import str_or_build_locale
-
-
-class TestBuilder(crescent.LocaleBuilder):
-    def build(self):
-        return "LOCALES"
-
-    def default(self):
-        return "DEFAULT"
+from tests.utils import Locale
 
 
 def test_str_or_build_locale():
-    default, locales = str_or_build_locale(TestBuilder())
+    default, locales = str_or_build_locale(Locale("default", en_US="en-localization"))
 
-    assert default == "DEFAULT"
-    assert locales == "LOCALES"
+    assert default == "default"
+    assert locales == {"en-US": "en-localization"}
 
     default, locales = str_or_build_locale("test")
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,6 +1,7 @@
 from typing import Sequence
 
 from tests.utils.arrays import arrays_contain_same_elements
+from tests.utils.locale import Locale
 from tests.utils.mock_bot import MockBot
 
-__all__: Sequence[str] = ("MockBot", "arrays_contain_same_elements")
+__all__: Sequence[str] = ("MockBot", "arrays_contain_same_elements", "Locale")

--- a/tests/utils/locale.py
+++ b/tests/utils/locale.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from crescent import LocaleBuilder
+
+__all__: Sequence[str] = ("Locale",)
+
+
+@dataclass
+class Locale(LocaleBuilder):
+
+    default_name: str
+    en_US: str | None = None
+
+    def build(self) -> dict[str, str]:
+        out: dict[str, str] = {}
+        if self.en_US:
+            out["en-US"] = self.en_US
+
+        return out
+
+    def default(self) -> str:
+        return self.default_name

--- a/tests/utils/locale.py
+++ b/tests/utils/locale.py
@@ -11,7 +11,7 @@ __all__: Sequence[str] = ("Locale",)
 @dataclass
 class Locale(LocaleBuilder):
 
-    default_name: str
+    _fallback: str
     en_US: str | None = None
 
     def build(self) -> dict[str, str]:
@@ -21,5 +21,6 @@ class Locale(LocaleBuilder):
 
         return out
 
-    def default(self) -> str:
-        return self.default_name
+    @property
+    def fallback(self) -> str:
+        return self._fallback


### PR DESCRIPTION
This PR adds `crescent.LocaleBuilder` which can be used to to write locale implementations. It is done like this so `crescent` is opinionated minimally in this area.

The `locale` field is also added to `crescent.BaseContext`. 