### PR TITLE
:bug: Move permissions to `crescent.Group`

### DIFF
--- a/crescent/__init__.py
+++ b/crescent/__init__.py
@@ -41,6 +41,7 @@ __all__: Sequence[str] = (
     "CrescentException",
     "AlreadyRegisteredError",
     "PluginAlreadyLoadedError",
+    "PermissionsError",
     "LocaleBuilder",
     "Mentionable",
     "CommandCallbackT",

--- a/crescent/exceptions.py
+++ b/crescent/exceptions.py
@@ -17,3 +17,7 @@ class AlreadyRegisteredError(CrescentException):
 
 class PluginAlreadyLoadedError(CrescentException):
     """A plugin is attempted to be loaded but the plugin manager already loaded the plugin."""
+
+
+class PermissionsError(CrescentException):
+    """Raise when a permission is declared in a subcommand"""

--- a/crescent/exceptions.py
+++ b/crescent/exceptions.py
@@ -4,6 +4,7 @@ __all__: Sequence[str] = (
     "CrescentException",
     "AlreadyRegisteredError",
     "PluginAlreadyLoadedError",
+    "PermissionsError",
 )
 
 

--- a/crescent/internal/registry.py
+++ b/crescent/internal/registry.py
@@ -179,9 +179,9 @@ class CommandHandler:
                         guild_id=command.metadata.app_command.guild_id,
                         options=[],
                         default_member_permissions=(
-                            command.metadata.app_command.default_member_permissions
+                            unwrap(command.metadata.group).default_member_permissions
                         ),
-                        is_dm_enabled=command.metadata.app_command.is_dm_enabled,
+                        is_dm_enabled=unwrap(command.metadata.group).dm_enabled,
                     )
 
                 # The top-level command now exists. A subcommand group now if placed
@@ -255,9 +255,9 @@ class CommandHandler:
                         guild_id=command.metadata.app_command.guild_id,
                         options=[],
                         default_member_permissions=(
-                            command.metadata.app_command.default_member_permissions
+                            command.metadata.group.default_member_permissions
                         ),
-                        is_dm_enabled=command.metadata.app_command.is_dm_enabled,
+                        is_dm_enabled=command.metadata.group.dm_enabled,
                     )
 
                 # No checking has to be done before appending `command` since it is the

--- a/tests/crescent/commands/test_permissions.py
+++ b/tests/crescent/commands/test_permissions.py
@@ -1,0 +1,50 @@
+from crescent import command, Group, Context, PermissionsError
+from pytest import raises
+from hikari import PermissionOverwrite
+
+
+def test_no_perms_in_subcommand_group():
+    group = Group("abcd")
+
+    with raises(PermissionsError):
+
+        @group.child
+        @command(dm_enabled=False)
+        async def _command(ctx: Context) -> None:
+            ...
+
+    with raises(PermissionsError):
+
+        @group.child
+        @command(default_member_permissions=PermissionOverwrite(id=0, type=0))
+        async def _command(ctx: Context) -> None:
+            ...
+
+    @group.child
+    @command
+    async def _command(ctx: Context) -> None:
+        ...
+
+
+def test_no_perms_in_subcommand_subgroup():
+    group = Group("abcd")
+    sub_group = group.sub_group("abcd")
+
+    with raises(PermissionsError):
+
+        @sub_group.child
+        @command(dm_enabled=False)
+        async def _command(ctx: Context) -> None:
+            ...
+
+    with raises(PermissionsError):
+
+        @sub_group.child
+        @command(default_member_permissions=PermissionOverwrite(id=0, type=0))
+        async def _command(ctx: Context) -> None:
+            ...
+
+    @sub_group.child
+    @command
+    async def _command(ctx: Context) -> None:
+        ...


### PR DESCRIPTION
Permissions v2 should be declared in the top level of the command. This PR adds that.