### PR TITLE
Improve internal descriptor API

### DIFF
--- a/crescent/commands/decorators.py
+++ b/crescent/commands/decorators.py
@@ -106,7 +106,7 @@ def command(
             if not isinstance(v, ClassCommandOption):
                 continue
 
-            generated = v._gen_option(n)
+            generated = v._build(n)
             options.append(generated)
 
             if v.autocomplete:

--- a/crescent/commands/options.py
+++ b/crescent/commands/options.py
@@ -88,11 +88,11 @@ T = TypeVar("T")
 Self = TypeVar("Self")
 
 
-class SentinalType:
+class NoValueType:
     ...
 
 
-SENTINEL = SentinalType()
+NO_VALUE = NoValueType()
 
 
 @dataclass
@@ -109,7 +109,7 @@ class ClassCommandOption(Generic[T]):
     max_length: int | None
     autocomplete: AutocompleteCallbackT | None
 
-    _value: T | SentinalType = SENTINEL
+    _value: T | NoValueType = NO_VALUE
 
     def _build(self, name: str) -> CommandOption:
         name, name_localizations = str_or_build_locale(self.name or name)
@@ -134,11 +134,11 @@ class ClassCommandOption(Generic[T]):
     def __get__(self, inst: Any, _: Any = None) -> T:
         assert inst, "Options can not be accessed before instantiating the class."
         assert not isinstance(
-            self._value, SentinalType
+            self._value, NoValueType
         ), "Options should be set before being accessed"
         return self._value
 
-    def __set__(self, inst: Any, value: T):
+    def __set__(self, inst: Any, value: T) -> None:
         assert inst, "Options can not be set before instantiating the class."
         self._value = value
 

--- a/crescent/commands/options.py
+++ b/crescent/commands/options.py
@@ -92,9 +92,6 @@ class NoValueType:
     ...
 
 
-NO_VALUE = NoValueType()
-
-
 @dataclass
 class ClassCommandOption(Generic[T]):
     name: str | LocaleBuilder | None
@@ -109,7 +106,7 @@ class ClassCommandOption(Generic[T]):
     max_length: int | None
     autocomplete: AutocompleteCallbackT | None
 
-    _value: T | NoValueType = NO_VALUE
+    _value: T | NoValueType = NoValueType()
 
     def _build(self, name: str) -> CommandOption:
         name, name_localizations = str_or_build_locale(self.name or name)

--- a/tests/utils/mock_client.py
+++ b/tests/utils/mock_client.py
@@ -34,6 +34,7 @@ class MockClient(Client):
     async def wait_until_ready(self):
         await self._wait_until_ready_event.wait()
 
+
 class MockBot(GatewayBot):
     def __init__(self):
         super().__init__(token="")


### PR DESCRIPTION
I decided to use asserts instead of exceptions because asserts are faster and its extremely unlikely a user will ever trigger those errors.