### PR TITLE
:boom: Use floodgate for ratelimiting

### DIFF
--- a/examples/ext/cooldowns/basic.py
+++ b/examples/ext/cooldowns/basic.py
@@ -1,3 +1,5 @@
+import datetime
+
 import hikari
 
 import crescent
@@ -9,19 +11,19 @@ client = crescent.Client(bot)
 
 # The user can use the command 3 times in 20 seconds.
 @client.include
-@crescent.hook(cooldowns.cooldown(3, 20))
+@crescent.hook(cooldowns.cooldown(3, datetime.timedelta(seconds=20)))
 @crescent.command
 async def my_command(ctx: crescent.Context) -> None:
     await ctx.respond("Hello!")
 
 
 # Callbacks can be set to run when a user is ratelimited.
-async def on_rate_limited(ctx: crescent.Context, time_remaining: float) -> None:
+async def on_rate_limited(ctx: crescent.Context, time_remaining: datetime.timedelta) -> None:
     await ctx.respond(f"You are ratelimited for {time_remaining}s.")
 
 
 @client.include
-@crescent.hook(cooldowns.cooldown(1, 100, callback=on_rate_limited))
+@crescent.hook(cooldowns.cooldown(1, datetime.timedelta(seconds=100), callback=on_rate_limited))
 @crescent.command
 async def my_command2(ctx: crescent.Context) -> None:
     await ctx.respond("Hello!")

--- a/examples/ext/cooldowns/custom_bucket.py
+++ b/examples/ext/cooldowns/custom_bucket.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import datetime
+
 import hikari
 
 import crescent
@@ -17,7 +19,9 @@ def guild_specific_rate_limits(
 
 # This function now has individual rate limit buckets for each guild.
 @client.include
-@crescent.hook(cooldowns.cooldown(3, 20, bucket=guild_specific_rate_limits))
+@crescent.hook(
+    cooldowns.cooldown(3, datetime.timedelta(seconds=20), bucket=guild_specific_rate_limits)
+)
 @crescent.command
 async def my_command(ctx: crescent.Context) -> None:
     await ctx.respond("Hello!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [{ include = "crescent" }]
 python = ">=3.8,<3.12"
 hikari = ">=2.0.0.dev115"
 sigparse = ">=1.3,<3.0"
-pycooldown = { version = ">=0.1.0-beta.8", optional = true }
+floodgate-rs = { version = "^0.1.1", optional = true }
 types-croniter = { version = "==1.0.11", optional = true }
 croniter = { version = "^1.3.5", optional = true }
 python-i18n = { version = ">=0.2", optional = true }
@@ -35,7 +35,7 @@ python-i18n = { version = ">=0.2", optional = true }
 [tool.poetry.extras]
 i18n = ["python-i18n"]
 cron = ["croniter", "types-croniter"]
-cooldowns = ["pycooldown"]
+cooldowns = ["floodgate-rs"]
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "^5.0.4"


### PR DESCRIPTION
This PR switches to floodgate for rate limiting. Change is made because pycooldown is no longer supported.

Breaking changes
- `datetime.timedelta` expected for cooldown duration
- `datetime.timedelta` returned for time left after being rate limited